### PR TITLE
Migrate Controllers to v10 

### DIFF
--- a/Classes/Controller/HcardsController.php
+++ b/Classes/Controller/HcardsController.php
@@ -52,7 +52,7 @@ class HcardsController extends ActionController
         HcardsRepository $hcardsRepository
     )
     {
-        parent::__construct($configurationManager);
+        $this->injectConfigurationManager($configurationManager);
         $this->hcardsRepository = $hcardsRepository;
     }
 

--- a/Classes/Controller/MediaController.php
+++ b/Classes/Controller/MediaController.php
@@ -51,7 +51,7 @@ class MediaController extends ActionController
         ConfigurationManagerInterface $configurationManager,
         MediaRepository $mediaRepository
     ) {
-        parent::__construct($configurationManager);
+        $this->injectConfigurationManager($configurationManager);
         $this->mediaRepository = $mediaRepository;
     }
 

--- a/Classes/Controller/PersonsController.php
+++ b/Classes/Controller/PersonsController.php
@@ -52,7 +52,7 @@ class PersonsController extends ActionController
         ConfigurationManagerInterface $configurationManager,
         PersonsRepository $personsRepository
     ) {
-        parent::__construct($configurationManager);
+        $this->injectConfigurationManager($configurationManager);
         $this->personsRepository = $personsRepository;
     }
 

--- a/Classes/Controller/ProjectsController.php
+++ b/Classes/Controller/ProjectsController.php
@@ -51,7 +51,7 @@ class ProjectsController extends ActionController
         ProjectsRepository $projectsRepository
     )
     {
-        parent::__construct($configurationManager);
+        $this->injectConfigurationManager($configurationManager);
         $this->projectsRepository = $projectsRepository;
     }
 

--- a/Classes/Controller/UnitsController.php
+++ b/Classes/Controller/UnitsController.php
@@ -51,7 +51,7 @@ class UnitsController extends ActionController
         UnitsRepository $unitsRepository
     )
     {
-        parent::__construct($configurationManager);
+        $this->injectConfigurationManager($configurationManager);
         $this->unitsRepository = $unitsRepository;
     }
 


### PR DESCRIPTION
by using injectConfigurationManager($configurationManager) instead of parent::__construct()