### PR TITLE
Migrate Persistence Mapping from TypoScript to Classes.php according …

### DIFF
--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types = 1);
+
+return [
+    # hcard academy classes need to be mapped to hcard academy tables since they contain an additional '_xyz'
+    \Digicademy\Academy\Domain\Model\HcardsAdr::class => [
+        'tableName' => 'tx_academy_domain_model_hcards_adr',
+    ],
+
+    \Digicademy\Academy\Domain\Model\HcardsAdrcomponents::class => [
+        'tableName' => 'tx_academy_domain_model_hcards_adrcomponents',
+    ],
+
+    \Digicademy\Academy\Domain\Model\HcardsTel::class =>[
+        'tableName' => 'tx_academy_domain_model_hcards_tel',
+    ],
+
+    \Digicademy\Academy\Domain\Model\HcardsEmail::class => [
+        'tableName' => 'tx_academy_domain_model_hcards_email',
+    ],
+
+    \Digicademy\Academy\Domain\Model\HcardsUrl::class => [
+        'tableName' => 'tx_academy_domain_model_hcards_url',
+    ],
+
+    # map the sys_file_collection table
+    \Digicademy\Academy\Domain\Model\FileCollection::class => [
+        'tableName' => 'sys_file_collection',
+    ],
+
+    # map the sys_category table
+    \Digicademy\Academy\Domain\Model\Categories::class => [
+        'tableName' => 'sys_category',
+    ],
+
+    # map news table
+    \Digicademy\Academy\Domain\Model\News::class => [
+        'tableName' => 'tx_news_domain_model_news',
+    ],
+
+    # map events table
+    \Digicademy\Academy\Domain\Model\Events::class => [
+        'tableName' => 'tx_news_domain_model_news',
+    ],
+];

--- a/Configuration/TypoScript/HTML/Plugins/setup.txt
+++ b/Configuration/TypoScript/HTML/Plugins/setup.txt
@@ -7,67 +7,6 @@ config.tx_extbase {
 }
 
 plugin.tx_academy {
-	persistence {
-		classes {
-
-			# hcard academy classes need to be mapped to hcard academy tables since they contain an additional '_xyz'
-			Digicademy\Academy\Domain\Model\HcardsAdr {
-				mapping {
-					tableName = tx_academy_domain_model_hcards_adr
-				}
-			}
-			Digicademy\Academy\Domain\Model\HcardsAdrcomponents {
-				mapping {
-					tableName = tx_academy_domain_model_hcards_adrcomponents
-				}
-			}
-			Digicademy\Academy\Domain\Model\HcardsTel {
-				mapping {
-					tableName = tx_academy_domain_model_hcards_tel
-				}
-			}
-			Digicademy\Academy\Domain\Model\HcardsEmail {
-				mapping {
-					tableName = tx_academy_domain_model_hcards_email
-				}
-			}
-			Digicademy\Academy\Domain\Model\HcardsUrl {
-				mapping {
-					tableName = tx_academy_domain_model_hcards_url
-				}
-			}
-
-			# map the sys_file_collection table
-			Digicademy\Academy\Domain\Model\FileCollection {
-				mapping {
-					tableName = sys_file_collection
-				}
-			}
-
-			# map the sys_category table
-			Digicademy\Academy\Domain\Model\Categories {
-				mapping {
-					tableName = sys_category
-				}
-			}
-
-			# map news table
-			Digicademy\Academy\Domain\Model\News {
-				mapping {
-					tableName = tx_news_domain_model_news
-				}
-			}
-
-			# map events table
-			Digicademy\Academy\Domain\Model\Events {
-				mapping {
-					tableName = tx_news_domain_model_news
-				}
-			}
-
-		}
-	}
-
 	# paths for HTML views
 	view {
 		layoutRootPaths.10 = EXT:academy/Resources/Private/HTML/Layouts/


### PR DESCRIPTION
…to v10 documentation

* remove persistence config in Configuration/TypoScript/HTML/Plugins/setup.txt
* add Classes.php with new way of mapping

@metacontext Not sure if this is useful for you, if not just close it 😸 