### PR TITLE
Update ics templates and partial for strict RFC 5545 compliance.

### DIFF
--- a/Resources/Private/ICS/Partials/Events/Item.ics
+++ b/Resources/Private/ICS/Partials/Events/Item.ics
@@ -1,9 +1,10 @@
 <f:variable name="dateTimeFormat" value="Ymd\THis\Z"/>
 BEGIN:VEVENT
+UID:<f:format.date format="{dateTimeFormat}">{newsItem.datetime}</f:format.date>-{newsItem.uid}-{newsItem.pathSegment}
 SUMMARY:{newsItem.title}
 DESCRIPTION:{newsItem.teaser}
 DTSTAMP:<f:format.date format="{dateTimeFormat}">{newsItem.datetime}</f:format.date>
-DTSTART:<f:format.date format="{dateTimeFormat}">{newsItem.datetime}</f:format.date>
-<f:if condition="{newsItem.eventEnd}"><f:then>DTEND:<f:format.date format="{dateTimeFormat}">{newsItem.eventEnd}</f:format.date></f:then></f:if>
-<f:if condition="{newsItem.location}">LOCATION:{newsItem.location}</f:if>
+DTSTART:<f:format.date format="{dateTimeFormat}">{newsItem.datetime}</f:format.date><f:if condition="{newsItem.eventEnd}"><f:then><f:format.raw>
+DTEND:<f:format.date format="{dateTimeFormat}">{newsItem.eventEnd}</f:format.date></f:format.raw></f:then></f:if><f:if condition="{newsItem.location}"><f:format.raw>
+LOCATION:{newsItem.location}</f:format.raw></f:if>
 END:VEVENT

--- a/Resources/Private/ICS/Templates/News/Detail.ics
+++ b/Resources/Private/ICS/Templates/News/Detail.ics
@@ -1,8 +1,3 @@
 BEGIN:VCALENDAR
-
-    VERSION:2.0
-    PRODID:-//XYZ Corp//My Product//EN
-
-    <f:render partial="Events/Item" arguments="{newsItem: newsItem, settings: settings}"/>
-
-END:VCALENDAR
+VERSION:2.0
+PRODID:-//XYZ Corp//My Product//EN<f:render partial="Events/Item" arguments="{newsItem: newsItem, settings: settings}"/>END:VCALENDAR

--- a/Resources/Private/ICS/Templates/News/List.ics
+++ b/Resources/Private/ICS/Templates/News/List.ics
@@ -1,13 +1,7 @@
 BEGIN:VCALENDAR
-
-    VERSION:2.0
-    PRODID:-//XYZ Corp//My Product//EN
-
-    <f:if condition="{news}">
-        <f:for each="{news}" as="newsItem">
-
-           <f:render partial="Events/Item" arguments="{newsItem: newsItem, settings: settings}"/>
-
-        </f:for>
-    </f:if>
-END:VCALENDAR
+VERSION:2.0
+PRODID:-//XYZ Corp//My Product//EN<f:if condition="{news}">
+    <f:for each="{news}" as="newsItem">
+       <f:render partial="Events/Item" arguments="{newsItem: newsItem, settings: settings}"/>
+    </f:for>
+</f:if>END:VCALENDAR


### PR DESCRIPTION
Updates for ICS templates/partials to achieve strict RFC 5545 compliance.

- Removing whitespaces from lines beginnings, these should only occur in cases of deliberate line folding (see https://icalendar.org/iCalendar-RFC-5545/3-1-content-lines.html).
- Adding a UID to event component data as required (see https://icalendar.org/iCalendar-RFC-5545/3-6-1-event-component.html).*
- Set ICS templates to CRLF line ends (see https://icalendar.org/iCalendar-RFC-5545/3-1-content-lines.html).
- Blank line occurrences removed. While not technically an error, it's nicer not to have them.

Validated with https://icalendar.org/validator.html.

*) Because the domain name cannot be easily accesssed from the template, we cannot use `@domain.tld` as part of the UID, as would be ideal. Instead, the UID is a combination of event datetime, item uid, and the item path segment.
