### PR TITLE
Fix/typoscript conditions

### DIFF
--- a/Configuration/TypoScript/HTML/Plugins/events.txt
+++ b/Configuration/TypoScript/HTML/Plugins/events.txt
@@ -12,7 +12,7 @@ plugin.tx_news {
 	}
 }
 
-[PIDinRootline = 1305]
+[1305 in tree.rootLineIds]
 plugin.tx_news {
 	settings {
 		dateField = tx_roqnewsevent_startdate

--- a/Configuration/TypoScript/ICS/setup.txt
+++ b/Configuration/TypoScript/ICS/setup.txt
@@ -37,7 +37,7 @@ ics {
 	}
 }
 
-[globalVar = TSFE:type = 9828]
+[getTSFE().type == 9828]
 
 	lib.stdheader >
 	tt_content.stdWrap.innerWrap >
@@ -46,7 +46,7 @@ ics {
 
 [global]
 
-[globalVar = TSFE:id = 2121]
+[getTSFE().id == 2121]
 
 ics.10.switchableControllerActions.News.1 = eventDetail
 

--- a/Configuration/TypoScript/RSS/setup.txt
+++ b/Configuration/TypoScript/RSS/setup.txt
@@ -48,7 +48,7 @@ rss {
 	}
 }
 
-[globalVar = TSFE:type = 9818]
+[getTSFE().type == 9818]
 
 	lib.stdheader >
 	tt_content.stdWrap.innerWrap >

--- a/Configuration/TypoScript/VCF/Plugins/setup.txt
+++ b/Configuration/TypoScript/VCF/Plugins/setup.txt
@@ -1,4 +1,4 @@
-[globalVar = GP : type = 1122]
+[getTSFE().type == 1122]
 
 # set the view directories
 plugin.tx_academy.view {


### PR DESCRIPTION
Update of (some) legacy TypoScript conditions to Symfony ExpressionLanguage.

As of TYPO3 10, legacy condition syntax is no longer accepted and must be replaced, see https://docs.typo3.org/m/typo3/reference-typoscript/10.4/en-us/Conditions/Index.html