### PR TITLE
Remove attribute gender from persons in tx_academy

### DIFF
--- a/Classes/Domain/Model/Persons.php
+++ b/Classes/Domain/Model/Persons.php
@@ -47,13 +47,6 @@ class Persons extends AbstractEntity
     protected $persistentIdentifier;
 
     /**
-     * gender
-     *
-     * @var \integer $gender
-     */
-    protected $gender;
-
-    /**
      * Given name of the person
      *
      * @var \string $givenName
@@ -95,7 +88,7 @@ class Persons extends AbstractEntity
     protected $slug;
 
     /**
-     * gender
+     * sorting
      *
      * @var \string $sorting
      */
@@ -187,28 +180,6 @@ class Persons extends AbstractEntity
     public function setPersistentIdentifier($persistentIdentifier)
     {
         $this->persistentIdentifier = $persistentIdentifier;
-    }
-
-    /**
-     * Returns the gender
-     *
-     * @return \integer $gender
-     */
-    public function getGender()
-    {
-        return $this->gender;
-    }
-
-    /**
-     * Sets the gender
-     *
-     * @param \integer $gender
-     *
-     * @return void
-     */
-    public function setGender($gender)
-    {
-        $this->gender = $gender;
     }
 
     /**

--- a/Configuration/TCA/tx_academy_domain_model_persons.php
+++ b/Configuration/TCA/tx_academy_domain_model_persons.php
@@ -34,7 +34,6 @@ return array(
             l10n_diffsource, 
             hidden, 
             persistent_identifier,
-            gender, 
             honorific_prefix, 
             given_name, 
             additional_name, 
@@ -56,7 +55,6 @@ return array(
                 --div--;LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_persons.div1,
                     hidden,
                     persistent_identifier,
-                    gender,
                     honorific_prefix,
                     given_name,
                     additional_name,
@@ -168,27 +166,6 @@ return array(
                 'size' => 30,
                 'eval' => 'trim',
                 'readOnly' => 1
-            ),
-        ),
-        'gender' => array(
-            'exclude' => 1,
-            'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_persons.gender',
-            'config' => array(
-                'type' => 'radio',
-                'items' => array(
-                    array(
-                        'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_persons.gender.type.I.0',
-                        0
-                    ),
-                    array(
-                        'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_persons.gender.type.I.1',
-                        1
-                    ),
-                    array(
-                        'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_persons.gender.type.I.2',
-                        2
-                    ),
-                ),
             ),
         ),
         'given_name' => array(

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -391,22 +391,6 @@
 				<source>Honorific suffix</source>
 				<target>Nachgestellte Titel</target>
 			</trans-unit>
-			<trans-unit id="tx_academy_domain_model_persons.gender" resname="tx_academy_domain_model_persons.gender"  approved="yes">
-				<source>Gender</source>
-				<target>Geschlecht</target>
-			</trans-unit>
-			<trans-unit id="tx_academy_domain_model_persons.gender.type.I.0" resname="tx_academy_domain_model_persons.gender.type.I.0"  approved="yes">
-				<source>male</source>
-				<target>männlich</target>
-			</trans-unit>
-			<trans-unit id="tx_academy_domain_model_persons.gender.type.I.1" resname="tx_academy_domain_model_persons.gender.type.I.1"  approved="yes">
-				<source>female</source>
-				<target>weiblich</target>
-			</trans-unit>
-			<trans-unit id="tx_academy_domain_model_persons.gender.type.I.2" resname="tx_academy_domain_model_persons.gender.type.I.2"  approved="yes">
-				<source>non binary</source>
-				<target>nicht binär</target>
-			</trans-unit>
 			<trans-unit id="tx_academy_domain_model_persons.slug" resname="tx_academy_domain_model_persons.slug"  approved="yes">
 				<source>URL Path Segment</source>
 				<target>URL Pfadsegment</target>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -294,18 +294,6 @@
 			<trans-unit id="tx_academy_domain_model_persons.honorific_suffix" resname="tx_academy_domain_model_persons.honorific_suffix" >
 				<source>Honorific suffix</source>
 			</trans-unit>
-			<trans-unit id="tx_academy_domain_model_persons.gender" resname="tx_academy_domain_model_persons.gender" >
-				<source>Gender</source>
-			</trans-unit>
-			<trans-unit id="tx_academy_domain_model_persons.gender.type.I.0" resname="tx_academy_domain_model_persons.gender.type.I.0" >
-				<source>male</source>
-			</trans-unit>
-			<trans-unit id="tx_academy_domain_model_persons.gender.type.I.1" resname="tx_academy_domain_model_persons.gender.type.I.1" >
-				<source>female</source>
-			</trans-unit>
-			<trans-unit id="tx_academy_domain_model_persons.gender.type.I.2" resname="tx_academy_domain_model_persons.gender.type.I.2" >
-				<source>non binary</source>
-			</trans-unit>
 			<trans-unit id="tx_academy_domain_model_persons.slug" resname="tx_academy_domain_model_persons.slug" >
 				<source>URL Path Segment</source>
 			</trans-unit>

--- a/Resources/Private/VCF/Templates/Persons/Show.vcf
+++ b/Resources/Private/VCF/Templates/Persons/Show.vcf
@@ -2,14 +2,6 @@
 VERSION:3.0
 N;CHARSET=utf-8:{person.familyName};{person.givenName};{person.additionalNames};{person.honorificPrefix};{person.honorificSuffix}
 FN;CHARSET=utf-8:{person.honorificPrefix} {person.givenName} {person.additionalNames} {person.familyName} {person.honorificSuffix}
-<f:if condition="{person.gender} == 1">
-	<f:then>
-GENDER:F
-	</f:then>
-	<f:else>
-GENDER:M
-	</f:else>
-</f:if>
 <f:if condition="{person.expertise}">
 NOTE;CHARSET=utf-8:{person.expertise}
 </f:if>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -119,7 +119,6 @@ CREATE TABLE tx_academy_domain_model_persons (
 	pid int(11) DEFAULT '0' NOT NULL,
 
 	persistent_identifier varchar(255) DEFAULT '' NOT NULL,
-	gender tinyint(4) unsigned DEFAULT '0' NOT NULL,
 	given_name varchar(80) DEFAULT '' NOT NULL,
 	additional_name varchar(80) DEFAULT '' NOT NULL,
 	family_name varchar(80) DEFAULT '' NOT NULL,


### PR DESCRIPTION
Fix #19 Adaptions to remove the gender attribute of perons in tx_academy. This will remove the attribute of the domain model as well as the persons field from TCA, etx_tables.sql and Persons/show.vcf. If you want to keep the gender attribute for persons please take care to set it up in your project extension.