### PR TITLE
Add date ranges to domain model units to express temporal existence of a unit 

### DIFF
--- a/Classes/Domain/Model/Events.php
+++ b/Classes/Domain/Model/Events.php
@@ -37,7 +37,7 @@ class Events extends EventNews
 {
 
     /**
-     * Relations of the news with persons, projects, events, news, media etc.
+     * Relations of the event with persons, projects, events, news, media etc.
      *
      * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\Digicademy\Academy\Domain\Model\Relations>
      */

--- a/Classes/Domain/Model/Products.php
+++ b/Classes/Domain/Model/Products.php
@@ -45,14 +45,14 @@ class Products extends AbstractEntity
     protected $persistentIdentifier;
 
     /**
-     * The identifier of the project
+     * The identifier of the product
      *
      * @var \string $identifier
      */
     protected $identifier;
 
     /**
-     * The title of the project
+     * The title of the product
      *
      * @var \string $title
      * @Extbase\Validate("NotEmpty")
@@ -60,7 +60,7 @@ class Products extends AbstractEntity
     protected $title;
 
     /**
-     * An acronym for the project
+     * An acronym for the product
      *
      * @var \string $acronym
      */
@@ -72,14 +72,14 @@ class Products extends AbstractEntity
     protected $slug;
 
     /**
-     * The internal sorting for project list (if not alphabetic)
+     * The internal sorting for product list (if not alphabetic)
      *
      * @var \string $sorting
      */
     protected $sorting;
 
     /**
-     * A description of the projects scientific activities
+     * A description of the product
      *
      * @var \string $description
      */
@@ -101,21 +101,21 @@ class Products extends AbstractEntity
     protected $image = null;
 
     /**
-     * Duration of the project
+     * Duration of the product
      *
      * @var \Digicademy\ChfTime\Domain\Model\DateRanges $dateRange
      */
     protected $dateRange = null;
 
     /**
-     * The page where the project details are listed
+     * The page where the product details are listed
      *
      * @var \integer $page
      */
     protected $page;
 
     /**
-     * Relations of the project with persons, events, news, media etc.
+     * Relations of the product with persons, events, news, media etc.
      *
      * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\Digicademy\Academy\Domain\Model\Relations>
      * @Extbase\ORM\Lazy
@@ -123,7 +123,7 @@ class Products extends AbstractEntity
     protected $relations = null;
 
     /**
-     * Selected categories for the project
+     * Selected categories for the product
      *
      * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\Digicademy\Academy\Domain\Model\Categories>
      * @Extbase\ORM\Lazy

--- a/Classes/Domain/Model/Publications.php
+++ b/Classes/Domain/Model/Publications.php
@@ -47,14 +47,14 @@ class Publications extends AbstractEntity
     protected $persistentIdentifier;
 
     /**
-     * The identifier of the project
+     * The identifier of the publication
      *
      * @var \string $identifier
      */
     protected $identifier;
 
     /**
-     * The title of the project
+     * The title of the publication
      *
      * @var \string $title
      * @Extbase\Validate("NotEmpty")
@@ -137,7 +137,7 @@ class Publications extends AbstractEntity
     protected $slug;
 
     /**
-     * A description of the projects scientific activities
+     * A description of the publication
      *
      * @var \string $description
      */
@@ -159,21 +159,21 @@ class Publications extends AbstractEntity
     protected $image = null;
 
     /**
-     * Duration of the project
+     * Publication date of the publication
      *
      * @var \Digicademy\ChfTime\Domain\Model\DateRanges $dateRange
      */
     protected $dateRange = null;
 
     /**
-     * The page where the project details are listed
+     * The page where the publication details are listed
      *
      * @var \integer $page
      */
     protected $page;
 
     /**
-     * Relations of the project with persons, events, news, media etc.
+     * Relations of the publication with persons, events, news, media etc.
      *
      * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\Digicademy\Academy\Domain\Model\Relations>
      * @Extbase\ORM\Lazy
@@ -181,7 +181,7 @@ class Publications extends AbstractEntity
     protected $relations = null;
 
     /**
-     * Selected categories for the project
+     * Selected categories for the publication
      *
      * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\Digicademy\Academy\Domain\Model\Categories>
      * @Extbase\ORM\Lazy

--- a/Classes/Domain/Model/Services.php
+++ b/Classes/Domain/Model/Services.php
@@ -47,14 +47,14 @@ class Services extends AbstractEntity
     protected $persistentIdentifier;
 
     /**
-     * The identifier of the project
+     * The identifier of the service
      *
      * @var \string $identifier
      */
     protected $identifier;
 
     /**
-     * The title of the project
+     * The title of the service
      *
      * @var \string $title
      * @Extbase\Validate("NotEmpty")
@@ -62,7 +62,7 @@ class Services extends AbstractEntity
     protected $title;
 
     /**
-     * An acronym for the project
+     * An acronym for the service
      *
      * @var \string $acronym
      */
@@ -74,14 +74,14 @@ class Services extends AbstractEntity
     protected $slug;
 
     /**
-     * The internal sorting for project list (if not alphabetic)
+     * The internal sorting for service list (if not alphabetic)
      *
      * @var \string $sorting
      */
     protected $sorting;
 
     /**
-     * A description of the projects scientific activities
+     * A description of the services scientific activities
      *
      * @var \string $description
      */
@@ -104,14 +104,14 @@ class Services extends AbstractEntity
     protected $dateRange = null;
 
     /**
-     * The page where the project details are listed
+     * The page where the service details are listed
      *
      * @var \integer $page
      */
     protected $page;
 
     /**
-     * Relations of the project with persons, events, news, media etc.
+     * Relations of the service with persons, events, news, media etc.
      *
      * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\Digicademy\Academy\Domain\Model\Relations>
      * @Extbase\ORM\Lazy
@@ -119,7 +119,7 @@ class Services extends AbstractEntity
     protected $relations = null;
 
     /**
-     * Selected categories for the project
+     * Selected categories for the service
      *
      * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\Digicademy\Academy\Domain\Model\Categories>
      * @Extbase\ORM\Lazy

--- a/Classes/Domain/Model/Units.php
+++ b/Classes/Domain/Model/Units.php
@@ -27,6 +27,7 @@ namespace Digicademy\Academy\Domain\Model;
  ***************************************************************/
 
 use Digicademy\Academy\Domain\Repository\RelationsRepository;
+use Digicademy\ChfTime\Domain\Model\DateRanges;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Annotation as Extbase;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
@@ -92,6 +93,13 @@ class Units extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
      * @Extbase\ORM\Lazy
      */
     protected $image = null;
+
+    /**
+     * Temporal existence of the unit
+     *
+     * @var \Digicademy\ChfTime\Domain\Model\DateRanges $dateRange
+     */
+    protected $dateRange = null;
 
     /**
      * Relations of the unit with persons, events, news, media etc.
@@ -283,6 +291,28 @@ class Units extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     public function setImage($image)
     {
         $this->image = $image;
+    }
+
+    /**
+     * Returns the dateRange
+     *
+     * @return \Digicademy\ChfTime\Domain\Model\DateRanges $dateRange
+     */
+    public function getDateRange()
+    {
+        return $this->dateRange;
+    }
+
+    /**
+     * Sets the dateRange
+     *
+     * @param \Digicademy\ChfTime\Domain\Model\DateRanges $dateRange
+     *
+     * @return void
+     */
+    public function setDateRange(DateRanges $dateRange)
+    {
+        $this->dateRange = $dateRange;
     }
 
     /**

--- a/Configuration/TCA/tx_academy_domain_model_units.php
+++ b/Configuration/TCA/tx_academy_domain_model_units.php
@@ -52,6 +52,7 @@ return array(
                 acronym,
                 slug,
                 sorting,
+                date_range,
                 page,
             --div--;LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_units.div2,
                 image,
@@ -203,6 +204,31 @@ return array(
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
+            ),
+        ),
+        'date_range' => array(
+            'exclude' => 1,
+            'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xlf:tx_academy_domain_model_products.date_range',
+            'config' => array(
+                'type' => 'inline',
+                'foreign_table' => 'tx_chftime_domain_model_dateranges',
+                'foreign_field' => 'parent',
+                'foreign_table_field' => 'tablename',
+                'minitems' => 0,
+                'maxitems' => 1,
+                'behaviour' => array(
+                    'disableMovingChildrenWithParent' => 1,
+                ),
+                'appearance' => array(
+                    'collapseAll' => 1,
+                    'expandSingle' => 1,
+                    'newRecordLinkAddTitle' => 1,
+                    'newRecordLinkPosition' => 'bottom',
+                    'levelLinksPosition' => 'bottom',
+                    'showSynchronizationLink' => 1,
+                    'showPossibleLocalizationRecords' => 1,
+                    'showAllLocalizationLink' => 1
+                ),
             ),
         ),
         'page' => array(

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -82,6 +82,9 @@ CREATE TABLE tx_academy_domain_model_units (
 	# tx_academy_domain_model_relations (1:n)
 	relations int(11) unsigned DEFAULT '0' NOT NULL,
 
+    # tx_chftime_domain_model_dateranges (1:1)
+    date_range int(11) unsigned DEFAULT '0',
+
 	tstamp int(11) unsigned DEFAULT '0' NOT NULL,
 	crdate int(11) unsigned DEFAULT '0' NOT NULL,
 	deleted tinyint(4) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
closes #25 This Merge adds date ranges to domain model units to express the temporal existence of a unit. Additionally some comments are corrected in other domain models.