### PR TITLE
Feature: introduce possiblity to add content elements to projects, persons, products, publications, services and units 

### DIFF
--- a/Classes/Domain/Model/Persons.php
+++ b/Classes/Domain/Model/Persons.php
@@ -26,6 +26,7 @@ namespace Digicademy\Academy\Domain\Model;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use GeorgRinger\News\Domain\Model\TtContent;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Annotation as Extbase;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
@@ -108,6 +109,13 @@ class Persons extends AbstractEntity
      * @var \Digicademy\ChfTime\Domain\Model\DateRanges $dateRange
      */
     protected $dateRange = null;
+
+    /**
+     * Additional free text information about a person
+     *
+     * @var ObjectStorage<TtContent>
+     */
+    protected $contentElements;
 
     /**
      * A page where details about the person can be found
@@ -356,6 +364,27 @@ class Persons extends AbstractEntity
     public function setDateRange(DateRanges $dateRange)
     {
         $this->dateRange = $dateRange;
+    }
+
+    /**
+     * Get content elements
+     *
+     * @return ObjectStorage
+     */
+    public function getContentElements(): ObjectStorage
+    {
+        return $this->contentElements;
+    }
+
+    /**
+     * Set content element list
+     *
+     * @param ObjectStorage $contentElements content elements
+     * @return void
+     */
+    public function setContentElements(ObjectStorage $contentElements): void
+    {
+        $this->contentElements = $contentElements;
     }
 
     /**

--- a/Classes/Domain/Model/Products.php
+++ b/Classes/Domain/Model/Products.php
@@ -27,6 +27,7 @@ namespace Digicademy\Academy\Domain\Model;
  ***************************************************************/
 
 use Digicademy\Academy\Domain\Repository\RelationsRepository;
+use GeorgRinger\News\Domain\Model\TtContent;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Annotation as Extbase;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
@@ -84,6 +85,13 @@ class Products extends AbstractEntity
      * @var \string $description
      */
     protected $description;
+
+    /**
+     * Additional free text information about a product
+     *
+     * @var ObjectStorage<TtContent>
+     */
+    protected $contentElements;
 
     /**
      * A version of the product
@@ -304,6 +312,27 @@ class Products extends AbstractEntity
     public function setDescription($description)
     {
         $this->description = $description;
+    }
+
+    /**
+     * Get content elements
+     *
+     * @return ObjectStorage
+     */
+    public function getContentElements(): ObjectStorage
+    {
+        return $this->contentElements;
+    }
+
+    /**
+     * Set content element list
+     *
+     * @param ObjectStorage $contentElements content elements
+     * @return void
+     */
+    public function setContentElements(ObjectStorage $contentElements): void
+    {
+        $this->contentElements = $contentElements;
     }
 
     /**

--- a/Classes/Domain/Model/Projects.php
+++ b/Classes/Domain/Model/Projects.php
@@ -27,6 +27,7 @@ namespace Digicademy\Academy\Domain\Model;
  ***************************************************************/
 
 use Digicademy\Academy\Domain\Repository\RelationsRepository;
+use GeorgRinger\News\Domain\Model\TtContent;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Annotation as Extbase;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
@@ -86,6 +87,13 @@ class Projects extends AbstractEntity
      * @var \string $description
      */
     protected $description;
+
+    /**
+     * Additional free text information about a project
+     *
+     * @var ObjectStorage<TtContent>
+     */
+    protected $contentElements;
 
     /**
      * Image
@@ -277,6 +285,27 @@ class Projects extends AbstractEntity
     public function setDescription($description)
     {
         $this->description = $description;
+    }
+
+    /**
+     * Get content elements
+     *
+     * @return ObjectStorage
+     */
+    public function getContentElements(): ObjectStorage
+    {
+        return $this->contentElements;
+    }
+
+    /**
+     * Set content element list
+     *
+     * @param ObjectStorage $contentElements content elements
+     * @return void
+     */
+    public function setContentElements(ObjectStorage $contentElements): void
+    {
+        $this->contentElements = $contentElements;
     }
 
     /**

--- a/Classes/Domain/Model/Publications.php
+++ b/Classes/Domain/Model/Publications.php
@@ -27,6 +27,7 @@ namespace Digicademy\Academy\Domain\Model;
  ***************************************************************/
 
 use Digicademy\Academy\Domain\Repository\RelationsRepository;
+use GeorgRinger\News\Domain\Model\TtContent;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Annotation as Extbase;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
@@ -149,6 +150,13 @@ class Publications extends AbstractEntity
      * @var \string $bibliographicNote
      */
     protected $bibliographicNote;
+
+    /**
+     * Additional free text information about a publication
+     *
+     * @var ObjectStorage<TtContent>
+     */
+    protected $contentElements;
 
     /**
      * Image
@@ -538,6 +546,27 @@ class Publications extends AbstractEntity
     public function setBibliographicNote($bibliographicNote)
     {
         $this->bibliographicNote = $bibliographicNote;
+    }
+
+    /**
+     * Get content elements
+     *
+     * @return ObjectStorage
+     */
+    public function getContentElements(): ObjectStorage
+    {
+        return $this->contentElements;
+    }
+
+    /**
+     * Set content element list
+     *
+     * @param ObjectStorage $contentElements content elements
+     * @return void
+     */
+    public function setContentElements(ObjectStorage $contentElements): void
+    {
+        $this->contentElements = $contentElements;
     }
 
     /**

--- a/Classes/Domain/Model/Services.php
+++ b/Classes/Domain/Model/Services.php
@@ -27,6 +27,7 @@ namespace Digicademy\Academy\Domain\Model;
  ***************************************************************/
 
 use Digicademy\Academy\Domain\Repository\RelationsRepository;
+use GeorgRinger\News\Domain\Model\TtContent;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Annotation as Extbase;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
@@ -86,6 +87,13 @@ class Services extends AbstractEntity
      * @var \string $description
      */
     protected $description;
+
+    /**
+     * Additional free text information about a service
+     *
+     * @var ObjectStorage<TtContent>
+     */
+    protected $contentElements;
 
     /**
      * Image
@@ -266,6 +274,27 @@ class Services extends AbstractEntity
     public function getDescription()
     {
         return $this->description;
+    }
+
+    /**
+     * Get content elements
+     *
+     * @return ObjectStorage
+     */
+    public function getContentElements(): ObjectStorage
+    {
+        return $this->contentElements;
+    }
+
+    /**
+     * Set content element list
+     *
+     * @param ObjectStorage $contentElements content elements
+     * @return void
+     */
+    public function setContentElements(ObjectStorage $contentElements): void
+    {
+        $this->contentElements = $contentElements;
     }
 
     /**

--- a/Classes/Domain/Model/Units.php
+++ b/Classes/Domain/Model/Units.php
@@ -28,6 +28,7 @@ namespace Digicademy\Academy\Domain\Model;
 
 use Digicademy\Academy\Domain\Repository\RelationsRepository;
 use Digicademy\ChfTime\Domain\Model\DateRanges;
+use GeorgRinger\News\Domain\Model\TtContent;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Annotation as Extbase;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
@@ -78,6 +79,13 @@ class Units extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
      * @var \string $description
      */
     protected $description;
+
+    /**
+     * Additional free text information about a unit
+     *
+     * @var ObjectStorage<TtContent>
+     */
+    protected $contentElements;
 
     /**
      * The page where the unit details are listed
@@ -247,6 +255,27 @@ class Units extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     public function setDescription($description)
     {
         $this->description = $description;
+    }
+
+    /**
+     * Get content elements
+     *
+     * @return ObjectStorage
+     */
+    public function getContentElements(): ObjectStorage
+    {
+        return $this->contentElements;
+    }
+
+    /**
+     * Set content element list
+     *
+     * @param ObjectStorage $contentElements content elements
+     * @return void
+     */
+    public function setContentElements(ObjectStorage $contentElements): void
+    {
+        $this->contentElements = $contentElements;
     }
 
     /**

--- a/Configuration/TCA/Overrides/sys_category.php
+++ b/Configuration/TCA/Overrides/sys_category.php
@@ -1,11 +1,12 @@
 <?php
-if (!defined('TYPO3_MODE')) {
-    die ('Access denied.');
-}
+
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+defined('TYPO3') or die();
 
 // add field: persistent_identifier
 
-$tca = array(
+$tca = [
     'persistent_identifier' => [
         'exclude' => 1,
         'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:sys_category.persistent_identifier',
@@ -16,10 +17,10 @@ $tca = array(
             'readOnly' => 1
         ],
     ],
-);
+];
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('sys_category', $tca);
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
+ExtensionManagementUtility::addTCAcolumns('sys_category', $tca);
+ExtensionManagementUtility::addToAllTCAtypes(
     'sys_category',
     'persistent_identifier',
     '',

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,7 +1,26 @@
 <?php
-if (!defined('TYPO3_MODE')) {
-    die ('Access denied.');
-}
+
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+defined('TYPO3') or die();
+
+$tca = [
+    'tx_academy_parent' => [
+        'config' => [
+            'type' => 'passthrough',
+        ],
+    ],
+    'tx_academy_tablename' => [
+        'config' => [
+            'type' => 'passthrough',
+        ],
+    ],
+];
+
+ExtensionManagementUtility::addTCAcolumns(
+    'tt_content',
+    $tca,
+);
 
 $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['academy_projects'] = 'pi_flexform';
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue('academy_projects', 'FILE:EXT:academy/Configuration/FlexForms/ProjectsPlugin.xml');

--- a/Configuration/TCA/Overrides/tx_news_domain_model_news.php
+++ b/Configuration/TCA/Overrides/tx_news_domain_model_news.php
@@ -1,9 +1,10 @@
 <?php
-if (!defined('TYPO3_MODE')) {
-    die ('Access denied.');
-}
 
-$tca = array(
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+defined('TYPO3') or die();
+
+$tca = [
     'type' => [
         'exclude' => false,
         'label' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.doktype_formlabel',
@@ -25,12 +26,12 @@ $tca = array(
             'maxitems' => 1,
         ]
     ],
-    'news_relations' => array(
+    'news_relations' => [
         'exclude' => 1,
         'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_news.news_relations',
         'l10n_display' => 'defaultAsReadonly',
         'l10n_mode' => 'exclude',
-        'config' => array(
+        'config' => [
             'type' => 'inline',
             'foreign_table' => 'tx_academy_domain_model_relations',
             'foreign_field' => 'news',
@@ -39,16 +40,16 @@ $tca = array(
             'symmetric_field' => 'news_symmetric',
             'symmetric_sortby' => 'sorting_symmetric',
             'maxitems' => 9999,
-            'behaviour' => array(
+            'behaviour' => [
                 'disableMovingChildrenWithParent' => 1,
 //                    'allowLanguageSynchronization' => true,
-            ),
-            'appearance' => array(
+            ],
+            'appearance' => [
                 'collapseAll' => 1,
                 'expandSingle' => 1,
                 'useSortable' => true,
                 'levelLinksPosition' => 'bottom',
-            ),
+            ],
             'overrideChildTca' => [
                 'columns' => [
                     'type' => [
@@ -99,14 +100,14 @@ $tca = array(
                     ]
                 ],
             ],
-        ),
-    ),
-    'event_relations' => array(
+        ],
+    ],
+    'event_relations' => [
         'exclude' => 1,
         'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_news.event_relations',
         'l10n_display' => 'defaultAsReadonly',
         'l10n_mode' => 'exclude',
-        'config' => array(
+        'config' => [
             'type' => 'inline',
             'foreign_table' => 'tx_academy_domain_model_relations',
             'foreign_field' => 'event',
@@ -115,16 +116,16 @@ $tca = array(
             'symmetric_field' => 'event_symmetric',
             'symmetric_sortby' => 'sorting_symmetric',
             'maxitems' => 9999,
-            'behaviour' => array(
+            'behaviour' => [
                 'disableMovingChildrenWithParent' => 1,
 //                    'allowLanguageSynchronization' => true,
-            ),
-            'appearance' => array(
+            ],
+            'appearance' => [
                 'collapseAll' => 1,
                 'expandSingle' => 1,
                 'useSortable' => true,
                 'levelLinksPosition' => 'bottom',
-            ),
+            ],
             'overrideChildTca' => [
                 'columns' => [
                     'type' => [
@@ -175,22 +176,22 @@ $tca = array(
                     ]
                 ],
             ],
-        ),
-    ),
-);
+        ],
+    ],
+];
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('tx_news_domain_model_news', $tca);
+ExtensionManagementUtility::addTCAcolumns('tx_news_domain_model_news', $tca);
 
 $GLOBALS['TCA']['tx_news_domain_model_news']['types']['3']['showitem'] = $GLOBALS['TCA']['tx_news_domain_model_news']['types']['0']['showitem'];
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
+ExtensionManagementUtility::addToAllTCAtypes(
     'tx_news_domain_model_news',
     'news_relations',
     '0',
     ''
 );
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
+ExtensionManagementUtility::addToAllTCAtypes(
     'tx_news_domain_model_news',
     'event_relations',
     '3',

--- a/Configuration/TCA/tx_academy_domain_model_hcards.php
+++ b/Configuration/TCA/tx_academy_domain_model_hcards.php
@@ -1,10 +1,11 @@
 <?php
-if (!defined('TYPO3_MODE')) {
-    die ('Access denied.');
-}
 
-return array(
-    'ctrl' => array(
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+defined('TYPO3') or die();
+
+return [
+    'ctrl' => [
         'title' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards',
         'label' => 'label',
         'default_sortby' => 'ORDER BY label ASC',
@@ -17,15 +18,15 @@ return array(
         'transOrigPointerField' => 'l10n_parent',
         'transOrigDiffSourceField' => 'l10n_diffsource',
         'delete' => 'deleted',
-        'enablecolumns' => array(
+        'enablecolumns' => [
             'disabled' => 'hidden',
             'starttime' => 'starttime',
             'endtime' => 'endtime',
-        ),
+        ],
         'searchFields' => 'label,geo',
-        'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_hcards.svg'
-    ),
-    'interface' => array(
+        'iconfile' => ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_hcards.svg'
+    ],
+    'interface' => [
         'showRecordFieldList' => '
             hidden, 
             persistent_identifier,
@@ -40,9 +41,9 @@ return array(
             l10n_parent, 
             l10n_diffsource
         ',
-    ),
-    'types' => array(
-        '1' => array(
+    ],
+    'types' => [
+        '1' => [
             'showitem' => '
                 hidden,
                 persistent_identifier,
@@ -58,12 +59,12 @@ return array(
                 l10n_parent,
                 l10n_diffsource
             '
-        ),
-    ),
-    'palettes' => array(
-        '1' => array('showitem' => ''),
-    ),
-    'columns' => array(
+        ],
+    ],
+    'palettes' => [
+        '1' => ['showitem' => ''],
+    ],
+    'columns' => [
         'sys_language_uid' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
@@ -81,165 +82,165 @@ return array(
                 'default' => 0,
             ]
         ],
-        'l10n_parent' => array(
+        'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
             'exclude' => 1,
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.l18n_parent',
-            'config' => array(
+            'config' => [
                 'type' => 'select',
-                'items' => array(
-                    array('', 0),
-                ),
+                'items' => [
+                    ['', 0],
+                ],
                 'foreign_table' => 'tx_academy_domain_model_hcards',
                 'foreign_table_where' => 'AND tx_academy_domain_model_hcards.pid=###CURRENT_PID### AND tx_academy_domain_model_hcards.sys_language_uid IN (-1,0)',
-            ),
-        ),
-        'l10n_diffsource' => array(
-            'config' => array(
+            ],
+        ],
+        'l10n_diffsource' => [
+            'config' => [
                 'type' => 'passthrough',
-            ),
-        ),
-        't3ver_label' => array(
+            ],
+        ],
+        't3ver_label' => [
             'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.versionLabel',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '30',
                 'max' => '255',
-            )
-        ),
-        'hidden' => array(
+            ]
+        ],
+        'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
-            'config' => array(
+            'config' => [
                 'type' => 'check',
-            ),
-        ),
-        'starttime' => array(
+            ],
+        ],
+        'starttime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.starttime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '10',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-            ),
-        ),
-        'endtime' => array(
+            ],
+        ],
+        'endtime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.endtime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '8',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-                'range' => array(
+                'range' => [
                     'upper' => mktime(0, 0, 0, 12, 31, date('Y') + 10),
                     'lower' => mktime(0, 0, 0, date('m') - 1, date('d'), date('Y'))
-                ),
-            ),
-        ),
-        'persistent_identifier' => array(
+                ],
+            ],
+        ],
+        'persistent_identifier' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xlf:tx_academy_domain_model_hcards.persistent_identifier',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim',
                 'readOnly' => 1
-            ),
-        ),
-        'type' => array(
+            ],
+        ],
+        'type' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards.type',
-            'config' => array(
+            'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
-                'items' => array(
-                    array(
+                'items' => [
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards.type.I.1',
                         '1'
-                    ),
-                    array(
+                    ],
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards.type.I.2',
                         '2'
-                    ),
-                ),
+                    ],
+                ],
                 'size' => 1,
                 'maxitems' => 1,
-            ),
-        ),
-        'label' => array(
+            ],
+        ],
+        'label' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards.label',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 50,
                 'eval' => 'trim,required'
-            ),
-        ),
-        'adr' => array(
+            ],
+        ],
+        'adr' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards.adr',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'tx_academy_domain_model_hcards_adr',
                 'foreign_table' => 'tx_academy_domain_model_hcards_adr',
                 'MM' => 'tx_academy_hcards_adr_mm',
                 'maxitems' => 99,
-                'wizards' => array(
-                    'suggest' => array(
+                'wizards' => [
+                    'suggest' => [
                         'type' => 'suggest',
-                        'default' => array(
+                        'default' => [
                             'pidList' => '###PLACEHOLDER###',
-                        ),
-                    ),
-                    'add' => array(
+                        ],
+                    ],
+                    'add' => [
                         'type' => 'popup',
                         'JSopenParams' => 'height=550,width=780,status=0,menubar=0,scrollbars=1',
-                        'module' => array(
+                        'module' => [
                             'name' => 'wizard_add',
-                        ),
+                        ],
                         'title' => 'Create new record',
                         'icon' => 'actions-add',
-                        'params' => array(
+                        'params' => [
                             'table' => 'tx_academy_domain_model_hcards_adr',
                             'pid' => '###PAGE_TSCONFIG_ID###',
                             'setValue' => 'set'
-                        ),
-                    ),
-                    'edit' => array(
+                        ],
+                    ],
+                    'edit' => [
                         'type' => 'popup',
                         'JSopenParams' => 'height=350,width=580,status=0,menubar=0,scrollbars=1',
                         'popup_onlyOpenIfSelected' => 1,
-                        'module' => array(
+                        'module' => [
                             'name' => 'wizard_edit',
-                        ),
+                        ],
                         'title' => 'Edit',
                         'icon' => 'actions-open',
-                    ),
-                ),
-            ),
-        ),
-        'tel' => array(
+                    ],
+                ],
+            ],
+        ],
+        'tel' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards.tel',
-            'config' => array(
+            'config' => [
                 'type' => 'inline',
                 'foreign_table' => 'tx_academy_domain_model_hcards_tel',
                 'foreign_field' => 'parent',
                 'foreign_sortby' => 'sorting',
                 'maxitems' => 9999,
-                'behaviour' => array(
+                'behaviour' => [
                     'disableMovingChildrenWithParent' => 1,
-                ),
-                'appearance' => array(
+                ],
+                'appearance' => [
                     'collapseAll' => 1,
                     'expandSingle' => 1,
                     'newRecordLinkAddTitle' => 1,
@@ -248,22 +249,22 @@ return array(
                     'showSynchronizationLink' => 1,
                     'showPossibleLocalizationRecords' => 1,
                     'showAllLocalizationLink' => 1,
-                ),
-            ),
-        ),
-        'email' => array(
+                ],
+            ],
+        ],
+        'email' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards.email',
-            'config' => array(
+            'config' => [
                 'type' => 'inline',
                 'foreign_table' => 'tx_academy_domain_model_hcards_email',
                 'foreign_field' => 'parent',
                 'foreign_sortby' => 'sorting',
                 'maxitems' => 9999,
-                'behaviour' => array(
+                'behaviour' => [
                     'disableMovingChildrenWithParent' => 1,
-                ),
-                'appearance' => array(
+                ],
+                'appearance' => [
                     'collapseAll' => 1,
                     'expandSingle' => 1,
                     'newRecordLinkAddTitle' => 1,
@@ -272,22 +273,22 @@ return array(
                     'showSynchronizationLink' => 1,
                     'showPossibleLocalizationRecords' => 1,
                     'showAllLocalizationLink' => 1,
-                ),
-            ),
-        ),
-        'url' => array(
+                ],
+            ],
+        ],
+        'url' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards.url',
-            'config' => array(
+            'config' => [
                 'type' => 'inline',
                 'foreign_table' => 'tx_academy_domain_model_hcards_url',
                 'foreign_field' => 'parent',
                 'foreign_sortby' => 'sorting',
                 'maxitems' => 9999,
-                'behaviour' => array(
+                'behaviour' => [
                     'disableMovingChildrenWithParent' => 1,
-                ),
-                'appearance' => array(
+                ],
+                'appearance' => [
                     'collapseAll' => 1,
                     'expandSingle' => 1,
                     'newRecordLinkAddTitle' => 1,
@@ -296,18 +297,18 @@ return array(
                     'showSynchronizationLink' => 1,
                     'showPossibleLocalizationRecords' => 1,
                     'showAllLocalizationLink' => 1,
-                ),
-            ),
-        ),
-        'geo' => array(
+                ],
+            ],
+        ],
+        'geo' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards.geo',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
+            ],
+        ],
         'slug' => [
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards.slug',
             'exclude' => 1,
@@ -325,5 +326,5 @@ return array(
                 'default' => ''
             ],
         ],
-    ),
-);
+    ],
+];

--- a/Configuration/TCA/tx_academy_domain_model_hcards_adr.php
+++ b/Configuration/TCA/tx_academy_domain_model_hcards_adr.php
@@ -1,10 +1,11 @@
 <?php
-if (!defined('TYPO3_MODE')) {
-    die ('Access denied.');
-}
 
-return array(
-    'ctrl' => array(
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+defined('TYPO3') or die();
+
+return [
+    'ctrl' => [
         'title' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_adr',
         'label' => 'label',
         'label_alt' => 'org',
@@ -19,15 +20,15 @@ return array(
         'transOrigPointerField' => 'l10n_parent',
         'transOrigDiffSourceField' => 'l10n_diffsource',
         'delete' => 'deleted',
-        'enablecolumns' => array(
+        'enablecolumns' => [
             'disabled' => 'hidden',
             'starttime' => 'starttime',
             'endtime' => 'endtime',
-        ),
+        ],
         'searchFields' => 'label,org',
-        'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_hcards_adr.svg'
-    ),
-    'interface' => array(
+        'iconfile' => ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_hcards_adr.svg'
+    ],
+    'interface' => [
         'showRecordFieldList' => '
             hidden, 
             type, 
@@ -39,9 +40,9 @@ return array(
             l10n_diffsource, 
             sorting
         ',
-    ),
-    'types' => array(
-        '1' => array(
+    ],
+    'types' => [
+        '1' => [
             'showitem' => '
                 hidden,
                 type,
@@ -53,12 +54,12 @@ return array(
                 l10n_diffsource,
                 sorting
         '
-        ),
-    ),
-    'palettes' => array(
-        '1' => array('showitem' => ''),
-    ),
-    'columns' => array(
+        ],
+    ],
+    'palettes' => [
+        '1' => ['showitem' => ''],
+    ],
+    'columns' => [
         'sys_language_uid' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
@@ -76,146 +77,146 @@ return array(
                 'default' => 0,
             ]
         ],
-        'l10n_parent' => array(
+        'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
             'exclude' => 1,
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.l18n_parent',
-            'config' => array(
+            'config' => [
                 'type' => 'select',
-                'items' => array(
-                    array('', 0),
-                ),
+                'items' => [
+                    ['', 0],
+                ],
                 'foreign_table' => 'tx_academy_domain_model_hcards_adr',
                 'foreign_table_where' => 'AND tx_academy_domain_model_hcards_adr.pid=###CURRENT_PID### AND tx_academy_domain_model_hcards_adr.sys_language_uid IN (-1,0)',
-            ),
-        ),
-        'l10n_diffsource' => array(
-            'config' => array(
+            ],
+        ],
+        'l10n_diffsource' => [
+            'config' => [
                 'type' => 'passthrough',
-            ),
-        ),
-        't3ver_label' => array(
+            ],
+        ],
+        't3ver_label' => [
             'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.versionLabel',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'max' => '255',
-            )
-        ),
-        'sorting' => array(
-            'config' => array(
+            ]
+        ],
+        'sorting' => [
+            'config' => [
                 'type' => 'passthrough',
-            ),
-        ),
-        'hidden' => array(
+            ],
+        ],
+        'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
-            'config' => array(
+            'config' => [
                 'type' => 'check',
-            ),
-        ),
-        'starttime' => array(
+            ],
+        ],
+        'starttime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.starttime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '10',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-            ),
-        ),
-        'endtime' => array(
+            ],
+        ],
+        'endtime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.endtime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '8',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-                'range' => array(
+                'range' => [
                     'upper' => mktime(0, 0, 0, 12, 31, date('Y') + 10),
                     'lower' => mktime(0, 0, 0, date('m') - 1, date('d'), date('Y'))
-                ),
-            ),
-        ),
-        'label' => array(
+                ],
+            ],
+        ],
+        'label' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_adr.label',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 50,
                 'eval' => 'trim'
-            ),
-        ),
-        'org' => array(
+            ],
+        ],
+        'org' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_adr.org',
-            'config' => array(
+            'config' => [
                 'type' => 'text',
                 'rows' => 5,
                 'cols' => 30,
                 'eval' => 'trim'
-            ),
-        ),
-        'type' => array(
+            ],
+        ],
+        'type' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_adr.type',
-            'config' => array(
+            'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
-                'items' => array(
-                    array(
+                'items' => [
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_adr.type.I.1',
                         '1'
-                    ),
-                    array(
+                    ],
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_adr.type.I.2',
                         '2'
-                    ),
-                    array(
+                    ],
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_adr.type.I.3',
                         '3'
-                    ),
-                    array(
+                    ],
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_adr.type.I.4',
                         '4'
-                    ),
-                    array(
+                    ],
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_adr.type.I.5',
                         '5'
-                    ),
-                    array(
+                    ],
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_adr.type.I.6',
                         '6'
-                    ),
-                    array(
+                    ],
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_adr.type.I.7',
                         '7'
-                    ),
-                ),
+                    ],
+                ],
                 'size' => 1,
                 'maxitems' => 1,
                 'eval' => 'required'
-            ),
-        ),
-        'adrcomponents' => array(
+            ],
+        ],
+        'adrcomponents' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_adr.adrcomponents',
-            'config' => array(
+            'config' => [
                 'type' => 'inline',
                 'foreign_table' => 'tx_academy_domain_model_hcards_adrcomponents',
                 'foreign_field' => 'parent',
                 'foreign_sortby' => 'sorting',
                 'maxitems' => 9999,
-                'behaviour' => array(
+                'behaviour' => [
                     'disableMovingChildrenWithParent' => 1,
-                ),
-                'appearance' => array(
+                ],
+                'appearance' => [
                     'collapseAll' => 1,
                     'expandSingle' => 1,
                     'newRecordLinkAddTitle' => 1,
@@ -224,8 +225,8 @@ return array(
                     'showSynchronizationLink' => 1,
                     'showPossibleLocalizationRecords' => 1,
                     'showAllLocalizationLink' => 1,
-                ),
-            ),
-        ),
-    ),
-);
+                ],
+            ],
+        ],
+    ],
+];

--- a/Configuration/TCA/tx_academy_domain_model_hcards_adrcomponents.php
+++ b/Configuration/TCA/tx_academy_domain_model_hcards_adrcomponents.php
@@ -1,10 +1,11 @@
 <?php
-if (!defined('TYPO3_MODE')) {
-    die ('Access denied.');
-}
 
-return array(
-    'ctrl' => array(
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+defined('TYPO3') or die();
+
+return [
+    'ctrl' => [
         'title' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_adrcomponents',
         'label' => 'value',
         'default_sortby' => 'ORDER BY parent, type ASC',
@@ -17,15 +18,15 @@ return array(
         'transOrigPointerField' => 'l10n_parent',
         'transOrigDiffSourceField' => 'l10n_diffsource',
         'delete' => 'deleted',
-        'enablecolumns' => array(
+        'enablecolumns' => [
             'disabled' => 'hidden',
             'starttime' => 'starttime',
             'endtime' => 'endtime',
-        ),
+        ],
         'searchFields' => 'value',
-        'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_hcards_adrcomponents.svg'
-    ),
-    'interface' => array(
+        'iconfile' => ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_hcards_adrcomponents.svg'
+    ],
+    'interface' => [
         'showRecordFieldList' => '
             hidden, 
             parent, 
@@ -36,9 +37,9 @@ return array(
             l10n_diffsource, 
             sorting
         ',
-    ),
-    'types' => array(
-        '1' => array(
+    ],
+    'types' => [
+        '1' => [
             'showitem' => '
                 hidden,
                 parent,
@@ -49,12 +50,12 @@ return array(
                 l10n_diffsource,
                 sorting
         '
-        ),
-    ),
-    'palettes' => array(
-        '1' => array('showitem' => ''),
-    ),
-    'columns' => array(
+        ],
+    ],
+    'palettes' => [
+        '1' => ['showitem' => ''],
+    ],
+    'columns' => [
         'sys_language_uid' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
@@ -72,77 +73,77 @@ return array(
                 'default' => 0,
             ]
         ],
-        'l10n_parent' => array(
+        'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
             'exclude' => 1,
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.l18n_parent',
-            'config' => array(
+            'config' => [
                 'type' => 'select',
-                'items' => array(
-                    array('', 0),
-                ),
+                'items' => [
+                    ['', 0],
+                ],
                 'foreign_table' => 'tx_academy_domain_model_hcards_adrcomponents',
                 'foreign_table_where' => 'AND tx_academy_domain_model_hcards_adrcomponents.pid=###CURRENT_PID### AND tx_academy_domain_model_hcards_adrcomponents.sys_language_uid IN (-1,0)',
-            ),
-        ),
-        'l10n_diffsource' => array(
-            'config' => array(
+            ],
+        ],
+        'l10n_diffsource' => [
+            'config' => [
                 'type' => 'passthrough',
-            ),
-        ),
-        't3ver_label' => array(
+            ],
+        ],
+        't3ver_label' => [
             'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.versionLabel',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'max' => '255',
-            )
-        ),
-        'sorting' => array(
-            'config' => array(
+            ]
+        ],
+        'sorting' => [
+            'config' => [
                 'type' => 'passthrough',
-            ),
-        ),
-        'hidden' => array(
+            ],
+        ],
+        'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
-            'config' => array(
+            'config' => [
                 'type' => 'check',
-            ),
-        ),
-        'starttime' => array(
+            ],
+        ],
+        'starttime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.starttime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '10',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-            ),
-        ),
-        'endtime' => array(
+            ],
+        ],
+        'endtime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.endtime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '8',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-                'range' => array(
+                'range' => [
                     'upper' => mktime(0, 0, 0, 12, 31, date('Y') + 10),
                     'lower' => mktime(0, 0, 0, date('m') - 1, date('d'), date('Y'))
-                ),
-            ),
-        ),
-        'parent' => array(
+                ],
+            ],
+        ],
+        'parent' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_adrcomponents.parent',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'tx_academy_domain_model_hcards',
@@ -151,62 +152,62 @@ return array(
                 'size' => 1,
                 'eval' => 'int',
                 'default' => 0,
-            ),
-        ),
-        'type' => array(
+            ],
+        ],
+        'type' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_adrcomponents.type',
-            'config' => array(
+            'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
-                'items' => array(
-                    array(
+                'items' => [
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_adrcomponents.type.I.1',
                         '1'
-                    ),
-                    array(
+                    ],
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_adrcomponents.type.I.2',
                         '2'
-                    ),
-                    array(
+                    ],
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_adrcomponents.type.I.3',
                         '3'
-                    ),
-                    array(
+                    ],
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_adrcomponents.type.I.4',
                         '4'
-                    ),
-                    array(
+                    ],
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_adrcomponents.type.I.5',
                         '5'
-                    ),
-                    array(
+                    ],
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_adrcomponents.type.I.6',
                         '6'
-                    ),
-                    array(
+                    ],
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_adrcomponents.type.I.7',
                         '7'
-                    ),
-                    array(
+                    ],
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_adrcomponents.type.I.8',
                         '8'
-                    ),
-                ),
+                    ],
+                ],
                 'size' => 1,
                 'maxitems' => 1,
                 'eval' => 'required'
-            ),
-        ),
-        'value' => array(
+            ],
+        ],
+        'value' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_adrcomponents.value',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '255',
                 'max' => '255',
                 'eval' => 'trim'
-            ),
-        ),
-    ),
-);
+            ],
+        ],
+    ],
+];

--- a/Configuration/TCA/tx_academy_domain_model_hcards_email.php
+++ b/Configuration/TCA/tx_academy_domain_model_hcards_email.php
@@ -1,10 +1,11 @@
 <?php
-if (!defined('TYPO3_MODE')) {
-    die ('Access denied.');
-}
 
-return array(
-    'ctrl' => array(
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+defined('TYPO3') or die();
+
+return [
+    'ctrl' => [
         'title' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_email',
         'label' => 'value',
         'default_sortby' => 'ORDER BY parent, type ASC',
@@ -17,15 +18,15 @@ return array(
         'transOrigPointerField' => 'l10n_parent',
         'transOrigDiffSourceField' => 'l10n_diffsource',
         'delete' => 'deleted',
-        'enablecolumns' => array(
+        'enablecolumns' => [
             'disabled' => 'hidden',
             'starttime' => 'starttime',
             'endtime' => 'endtime',
-        ),
+        ],
         'searchFields' => 'value',
-        'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_hcards_email.svg'
-    ),
-    'interface' => array(
+        'iconfile' => ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_hcards_email.svg'
+    ],
+    'interface' => [
         'showRecordFieldList' => '
             hidden, 
             parent, 
@@ -37,9 +38,9 @@ return array(
             l10n_diffsource, 
             sorting
         ',
-    ),
-    'types' => array(
-        '1' => array(
+    ],
+    'types' => [
+        '1' => [
             'showitem' => '
                 hidden,
                 parent,
@@ -51,12 +52,12 @@ return array(
                 l10n_diffsource,
                 sorting
         '
-        ),
-    ),
-    'palettes' => array(
-        '1' => array('showitem' => ''),
-    ),
-    'columns' => array(
+        ],
+    ],
+    'palettes' => [
+        '1' => ['showitem' => ''],
+    ],
+    'columns' => [
         'sys_language_uid' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
@@ -74,77 +75,77 @@ return array(
                 'default' => 0,
             ]
         ],
-        'l10n_parent' => array(
+        'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
             'exclude' => 1,
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.l18n_parent',
-            'config' => array(
+            'config' => [
                 'type' => 'select',
-                'items' => array(
-                    array('', 0),
-                ),
+                'items' => [
+                    ['', 0],
+                ],
                 'foreign_table' => 'tx_academy_domain_model_hcards_email',
                 'foreign_table_where' => 'AND tx_academy_domain_model_hcards_email.pid=###CURRENT_PID### AND tx_academy_domain_model_hcards_email.sys_language_uid IN (-1,0)',
-            ),
-        ),
-        'l10n_diffsource' => array(
-            'config' => array(
+            ],
+        ],
+        'l10n_diffsource' => [
+            'config' => [
                 'type' => 'passthrough',
-            ),
-        ),
-        't3ver_label' => array(
+            ],
+        ],
+        't3ver_label' => [
             'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.versionLabel',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'max' => '255',
-            )
-        ),
-        'hidden' => array(
+            ]
+        ],
+        'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
-            'config' => array(
+            'config' => [
                 'type' => 'check',
-            ),
-        ),
-        'sorting' => array(
-            'config' => array(
+            ],
+        ],
+        'sorting' => [
+            'config' => [
                 'type' => 'passthrough',
-            ),
-        ),
-        'starttime' => array(
+            ],
+        ],
+        'starttime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.starttime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '10',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-            ),
-        ),
-        'endtime' => array(
+            ],
+        ],
+        'endtime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.endtime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '8',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-                'range' => array(
+                'range' => [
                     'upper' => mktime(0, 0, 0, 12, 31, date('Y') + 10),
                     'lower' => mktime(0, 0, 0, date('m') - 1, date('d'), date('Y'))
-                ),
-            ),
-        ),
-        'parent' => array(
+                ],
+            ],
+        ],
+        'parent' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_email.parent',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'tx_academy_domain_model_hcards',
@@ -153,44 +154,44 @@ return array(
                 'size' => 1,
                 'eval' => 'int',
                 'default' => 0,
-            ),
-        ),
-        'type' => array(
+            ],
+        ],
+        'type' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_email.type',
-            'config' => array(
+            'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
-                'items' => array(
-                    array(
+                'items' => [
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_email.type.I.31',
                         '31'
-                    ),
-                ),
+                    ],
+                ],
                 'size' => 1,
                 'maxitems' => 1,
                 'eval' => 'required'
-            ),
-        ),
-        'value' => array(
+            ],
+        ],
+        'value' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_email.value',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '255',
                 'max' => '255',
                 'eval' => 'trim'
-            ),
-        ),
-        'freetext' => array(
+            ],
+        ],
+        'freetext' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_email.freetext',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '255',
                 'max' => '255',
                 'eval' => 'trim'
-            ),
-        ),
-    ),
-);
+            ],
+        ],
+    ],
+];

--- a/Configuration/TCA/tx_academy_domain_model_hcards_tel.php
+++ b/Configuration/TCA/tx_academy_domain_model_hcards_tel.php
@@ -1,10 +1,11 @@
 <?php
-if (!defined('TYPO3_MODE')) {
-    die ('Access denied.');
-}
 
-return array(
-    'ctrl' => array(
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+defined('TYPO3') or die();
+
+return [
+    'ctrl' => [
         'title' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_tel',
         'label' => 'type',
         'label_alt' => 'value',
@@ -19,15 +20,15 @@ return array(
         'transOrigPointerField' => 'l10n_parent',
         'transOrigDiffSourceField' => 'l10n_diffsource',
         'delete' => 'deleted',
-        'enablecolumns' => array(
+        'enablecolumns' => [
             'disabled' => 'hidden',
             'starttime' => 'starttime',
             'endtime' => 'endtime',
-        ),
+        ],
         'searchFields' => 'value',
-        'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_hcards_tel.svg'
-    ),
-    'interface' => array(
+        'iconfile' => ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_hcards_tel.svg'
+    ],
+    'interface' => [
         'showRecordFieldList' => '
             hidden, 
             parent, 
@@ -39,9 +40,9 @@ return array(
             l10n_diffsource, 
             sorting
         ',
-    ),
-    'types' => array(
-        '1' => array(
+    ],
+    'types' => [
+        '1' => [
             'showitem' => '
                 hidden,
                 parent,
@@ -53,12 +54,12 @@ return array(
                 l10n_diffsource,
                 sorting
         '
-        ),
-    ),
-    'palettes' => array(
-        '1' => array('showitem' => ''),
-    ),
-    'columns' => array(
+        ],
+    ],
+    'palettes' => [
+        '1' => ['showitem' => ''],
+    ],
+    'columns' => [
         'sys_language_uid' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
@@ -76,77 +77,77 @@ return array(
                 'default' => 0,
             ]
         ],
-        'l10n_parent' => array(
+        'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
             'exclude' => 1,
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.l18n_parent',
-            'config' => array(
+            'config' => [
                 'type' => 'select',
-                'items' => array(
-                    array('', 0),
-                ),
+                'items' => [
+                    ['', 0],
+                ],
                 'foreign_table' => 'tx_academy_domain_model_hcards_tel',
                 'foreign_table_where' => 'AND tx_academy_domain_model_hcards_tel.pid=###CURRENT_PID### AND tx_academy_domain_model_hcards_tel.sys_language_uid IN (-1,0)',
-            ),
-        ),
-        'l10n_diffsource' => array(
-            'config' => array(
+            ],
+        ],
+        'l10n_diffsource' => [
+            'config' => [
                 'type' => 'passthrough',
-            ),
-        ),
-        't3ver_label' => array(
+            ],
+        ],
+        't3ver_label' => [
             'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.versionLabel',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'max' => '255',
-            )
-        ),
-        'hidden' => array(
+            ]
+        ],
+        'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
-            'config' => array(
+            'config' => [
                 'type' => 'check',
-            ),
-        ),
-        'sorting' => array(
-            'config' => array(
+            ],
+        ],
+        'sorting' => [
+            'config' => [
                 'type' => 'passthrough',
-            ),
-        ),
-        'starttime' => array(
+            ],
+        ],
+        'starttime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.starttime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '10',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-            ),
-        ),
-        'endtime' => array(
+            ],
+        ],
+        'endtime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.endtime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '8',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-                'range' => array(
+                'range' => [
                     'upper' => mktime(0, 0, 0, 12, 31, date('Y') + 10),
                     'lower' => mktime(0, 0, 0, date('m') - 1, date('d'), date('Y'))
-                ),
-            ),
-        ),
-        'parent' => array(
+                ],
+            ],
+        ],
+        'parent' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_tel.parent',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'tx_academy_domain_model_hcards',
@@ -155,56 +156,56 @@ return array(
                 'size' => 1,
                 'eval' => 'int',
                 'default' => 0,
-            ),
-        ),
-        'type' => array(
+            ],
+        ],
+        'type' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_tel.type',
-            'config' => array(
+            'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
-                'items' => array(
-                    array(
+                'items' => [
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_tel.type.I.21',
                         '21'
-                    ),
-                    array(
+                    ],
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_tel.type.I.22',
                         '22'
-                    ),
-                    array(
+                    ],
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_tel.type.I.23',
                         '23'
-                    ),
-                    array(
+                    ],
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_tel.type.I.24',
                         '24'
-                    ),
-                ),
+                    ],
+                ],
                 'size' => 1,
                 'maxitems' => 1,
                 'eval' => 'required'
-            ),
-        ),
-        'value' => array(
+            ],
+        ],
+        'value' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_tel.value',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '255',
                 'max' => '255',
                 'eval' => 'trim'
-            ),
-        ),
-        'freetext' => array(
+            ],
+        ],
+        'freetext' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_tel.freetext',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '255',
                 'max' => '255',
                 'eval' => 'trim'
-            ),
-        ),
-    ),
-);
+            ],
+        ],
+    ],
+];

--- a/Configuration/TCA/tx_academy_domain_model_hcards_url.php
+++ b/Configuration/TCA/tx_academy_domain_model_hcards_url.php
@@ -1,10 +1,11 @@
 <?php
-if (!defined('TYPO3_MODE')) {
-    die ('Access denied.');
-}
 
-return array(
-    'ctrl' => array(
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+defined('TYPO3') or die();
+
+return [
+    'ctrl' => [
         'title' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_url',
         'label' => 'value',
         'default_sortby' => 'ORDER BY parent, type ASC',
@@ -17,15 +18,15 @@ return array(
         'transOrigPointerField' => 'l10n_parent',
         'transOrigDiffSourceField' => 'l10n_diffsource',
         'delete' => 'deleted',
-        'enablecolumns' => array(
+        'enablecolumns' => [
             'disabled' => 'hidden',
             'starttime' => 'starttime',
             'endtime' => 'endtime',
-        ),
+        ],
         'searchFields' => 'value',
-        'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_hcards_url.svg'
-    ),
-    'interface' => array(
+        'iconfile' => ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_hcards_url.svg'
+    ],
+    'interface' => [
         'showRecordFieldList' => '
             hidden, 
             parent, 
@@ -37,9 +38,9 @@ return array(
             l10n_diffsource, 
             sorting
         ',
-    ),
-    'types' => array(
-        '1' => array(
+    ],
+    'types' => [
+        '1' => [
             'showitem' => '
                 hidden,
                 parent,
@@ -51,12 +52,12 @@ return array(
                 l10n_diffsource,
                 sorting
         '
-        ),
-    ),
-    'palettes' => array(
-        '1' => array('showitem' => ''),
-    ),
-    'columns' => array(
+        ],
+    ],
+    'palettes' => [
+        '1' => ['showitem' => ''],
+    ],
+    'columns' => [
         'sys_language_uid' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
@@ -74,77 +75,77 @@ return array(
                 'default' => 0,
             ]
         ],
-        'l10n_parent' => array(
+        'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
             'exclude' => 1,
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.l18n_parent',
-            'config' => array(
+            'config' => [
                 'type' => 'select',
-                'items' => array(
-                    array('', 0),
-                ),
+                'items' => [
+                    ['', 0],
+                ],
                 'foreign_table' => 'tx_academy_domain_model_hcards_url',
                 'foreign_table_where' => 'AND tx_academy_domain_model_hcards_url.pid=###CURRENT_PID### AND tx_academy_domain_model_hcards_url.sys_language_uid IN (-1,0)',
-            ),
-        ),
-        'l10n_diffsource' => array(
-            'config' => array(
+            ],
+        ],
+        'l10n_diffsource' => [
+            'config' => [
                 'type' => 'passthrough',
-            ),
-        ),
-        't3ver_label' => array(
+            ],
+        ],
+        't3ver_label' => [
             'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.versionLabel',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'max' => '255',
-            )
-        ),
-        'hidden' => array(
+            ]
+        ],
+        'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
-            'config' => array(
+            'config' => [
                 'type' => 'check',
-            ),
-        ),
-        'sorting' => array(
-            'config' => array(
+            ],
+        ],
+        'sorting' => [
+            'config' => [
                 'type' => 'passthrough',
-            ),
-        ),
-        'starttime' => array(
+            ],
+        ],
+        'starttime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.starttime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '10',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-            ),
-        ),
-        'endtime' => array(
+            ],
+        ],
+        'endtime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.endtime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '8',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-                'range' => array(
+                'range' => [
                     'upper' => mktime(0, 0, 0, 12, 31, date('Y') + 10),
                     'lower' => mktime(0, 0, 0, date('m') - 1, date('d'), date('Y'))
-                ),
-            ),
-        ),
-        'parent' => array(
+                ],
+            ],
+        ],
+        'parent' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_url.parent',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'tx_academy_domain_model_hcards',
@@ -153,44 +154,44 @@ return array(
                 'size' => 1,
                 'eval' => 'int',
                 'default' => 0,
-            ),
-        ),
-        'type' => array(
+            ],
+        ],
+        'type' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_url.type',
-            'config' => array(
+            'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
-                'items' => array(
-                    array(
+                'items' => [
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_url.type.I.41',
                         '41'
-                    ),
-                ),
+                    ],
+                ],
                 'size' => 1,
                 'maxitems' => 1,
                 'eval' => 'required'
-            ),
-        ),
-        'value' => array(
+            ],
+        ],
+        'value' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_url.value',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '255',
                 'max' => '255',
                 'eval' => 'trim'
-            ),
-        ),
-        'freetext' => array(
+            ],
+        ],
+        'freetext' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_hcards_url.freetext',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '255',
                 'max' => '255',
                 'eval' => 'trim'
-            ),
-        ),
-    ),
-);
+            ],
+        ],
+    ],
+];

--- a/Configuration/TCA/tx_academy_domain_model_media.php
+++ b/Configuration/TCA/tx_academy_domain_model_media.php
@@ -1,10 +1,12 @@
 <?php
-if (!defined('TYPO3_MODE')) {
-    die ('Access denied.');
-}
 
-return array(
-    'ctrl' => array(
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+defined('TYPO3') or die();
+
+return [
+    'ctrl' => [
         'title' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_media',
         'label' => 'title',
         'default_sortby' => 'ORDER BY title ASC',
@@ -18,15 +20,15 @@ return array(
         'transOrigPointerField' => 'l10n_parent',
         'transOrigDiffSourceField' => 'l10n_diffsource',
         'delete' => 'deleted',
-        'enablecolumns' => array(
+        'enablecolumns' => [
             'disabled' => 'hidden',
             'starttime' => 'starttime',
             'endtime' => 'endtime',
-        ),
+        ],
         'searchFields' => 'title,description',
-        'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_media.svg'
-    ),
-    'interface' => array(
+        'iconfile' => ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_media.svg'
+    ],
+    'interface' => [
         'showRecordFieldList' => '
             sys_language_uid, 
             l10n_parent, 
@@ -42,9 +44,9 @@ return array(
             collections, 
             relations
         ',
-    ),
-    'types' => array(
-        '1' => array(
+    ],
+    'types' => [
+        '1' => [
             'showitem' => '
             --div--;LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_media.div1,
                 hidden,
@@ -64,12 +66,12 @@ return array(
                 l10n_parent,
                 l10n_diffsource
         '
-        ),
-    ),
-    'palettes' => array(
-        '1' => array('showitem' => ''),
-    ),
-    'columns' => array(
+        ],
+    ],
+    'palettes' => [
+        '1' => ['showitem' => ''],
+    ],
+    'columns' => [
         'sys_language_uid' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
@@ -87,137 +89,137 @@ return array(
                 'default' => 0,
             ]
         ],
-        'l10n_parent' => array(
+        'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
             'exclude' => 1,
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.l18n_parent',
-            'config' => array(
+            'config' => [
                 'type' => 'select',
-                'items' => array(
-                    array('', 0),
-                ),
+                'items' => [
+                    ['', 0],
+                ],
                 'foreign_table' => 'tx_academy_domain_model_media',
                 'foreign_table_where' => 'AND tx_academy_domain_model_media.pid=###CURRENT_PID### AND tx_academy_domain_model_media.sys_language_uid IN (-1,0)',
-            ),
-        ),
-        'l10n_diffsource' => array(
-            'config' => array(
+            ],
+        ],
+        'l10n_diffsource' => [
+            'config' => [
                 'type' => 'passthrough',
-            ),
-        ),
-        't3ver_label' => array(
+            ],
+        ],
+        't3ver_label' => [
             'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.versionLabel',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '30',
                 'max' => '255',
-            )
-        ),
-        'hidden' => array(
+            ]
+        ],
+        'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
-            'config' => array(
+            'config' => [
                 'type' => 'check',
-            ),
-        ),
-        'starttime' => array(
+            ],
+        ],
+        'starttime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.starttime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '10',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-            ),
-        ),
-        'endtime' => array(
+            ],
+        ],
+        'endtime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.endtime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '8',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-                'range' => array(
+                'range' => [
                     'upper' => mktime(0, 0, 0, 12, 31, date('Y') + 10),
                     'lower' => mktime(0, 0, 0, date('m') - 1, date('d'), date('Y'))
-                ),
-            ),
-        ),
-        'crdate' => array(
-            'config' => array(
+                ],
+            ],
+        ],
+        'crdate' => [
+            'config' => [
                 'type' => 'passthrough',
-            ),
-        ),
-        'persistent_identifier' => array(
+            ],
+        ],
+        'persistent_identifier' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xlf:tx_academy_domain_model_media.persistent_identifier',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim',
                 'readOnly' => 1
-            ),
-        ),
-        'type' => array(
+            ],
+        ],
+        'type' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_media.type',
-            'config' => array(
+            'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
-                'items' => array(
-                    array(
+                'items' => [
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_media.type.I.0',
                         '0'
-                    ),
-                    array(
+                    ],
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_media.type.I.10',
                         '10'
-                    ),
-                    array(
+                    ],
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_media.type.I.20',
                         '20'
-                    ),
-                    array(
+                    ],
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_media.type.I.30',
                         '30'
-                    ),
-                    array(
+                    ],
+                    [
                         'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_media.type.I.40',
                         '40'
-                    ),
-                ),
+                    ],
+                ],
                 'size' => 1,
                 'maxitems' => 1,
-            ),
-        ),
-        'title' => array(
+            ],
+        ],
+        'title' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_media.title',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 60,
                 'eval' => 'trim,required'
-            ),
-        ),
-        'description' => array(
+            ],
+        ],
+        'description' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_media.description',
-            'config' => array(
+            'config' => [
                 'type' => 'text',
                 'cols' => 40,
                 'rows' => 15,
                 'eval' => 'trim',
                 'softref' => 'rtehtmlarea_images,typolink_tag,images,email[subst],url',
                 'enableRichtext' => true,
-            ),
-        ),
+            ],
+        ],
         'slug' => [
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_media.slug',
             'exclude' => 1,
@@ -235,43 +237,43 @@ return array(
                 'default' => ''
             ],
         ],
-        'image' => array(
+        'image' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_media.image',
-            'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig('image', array(
-                'appearance' => array(
+            'config' => ExtensionManagementUtility::getFileFieldTCAConfig('image', [
+                'appearance' => [
                     'createNewRelationLinkTitle' => 'LLL:EXT:cms/locallang_ttc.xlf:images.addFileReference'
-                ),
+                ],
                 'minitems' => 0,
                 'maxitems' => 1,
-                'foreign_types' => array(
-                    '0' => array(
+                'foreign_types' => [
+                    '0' => [
                         'showitem' => '
                         --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
                         --palette--;;filePalette'
-                    ),
-                    \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => array(
+                    ],
+                    File::FILETYPE_IMAGE => [
                         'showitem' => '
                         --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
                         --palette--;;filePalette'
-                    ),
-                )
-            ),
+                    ],
+                ]
+            ],
             $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']),
-        ),
-        'files' => array(
+        ],
+        'files' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_media.files',
-            'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig('files', array(
-                'appearance' => array(
+            'config' => ExtensionManagementUtility::getFileFieldTCAConfig('files', [
+                'appearance' => [
                     'createNewRelationLinkTitle' => 'LLL:EXT:cms/locallang_ttc.xlf:media.addFileReference'
-                )
-            ))
-        ),
-        'collections' => array(
+                ]
+            ])
+        ],
+        'collections' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_media.collections',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'localizeReferencesAtParentLocalization' => true,
@@ -282,46 +284,46 @@ return array(
                 'eval' => 'int',
                 'default' => 0,
                 'size' => 5,
-                'wizards' => array(
-                    'suggest' => array(
+                'wizards' => [
+                    'suggest' => [
                         'type' => 'suggest',
-                        'default' => array(
+                        'default' => [
                             'pidList' => '###PLACEHOLDER###',
-                        ),
-                    ),
-                    'add' => Array(
+                        ],
+                    ],
+                    'add' => [
                         'type' => 'popup',
                         'title' => 'Create new',
                         'icon' => 'actions-add',
-                        'params' => array(
+                        'params' => [
                             'table' => 'sys_file_collection',
                             'pid' => '###PAGE_TSCONFIG_ID###',
                             'setValue' => 'prepend'
-                        ),
+                        ],
                         'JSopenParams' => 'height=350,width=580,status=0,menubar=0,scrollbars=1',
-                        'module' => array(
+                        'module' => [
                             'name' => 'wizard_add',
-                        ),
-                    ),
-                    'edit' => Array(
+                        ],
+                    ],
+                    'edit' => [
                         'type' => 'popup',
                         'title' => 'Edit record',
                         'icon' => 'actions-open',
                         'JSopenParams' => 'height=550,width=900,status=0,menubar=0,scrollbars=1',
                         'popup_onlyOpenIfSelected' => 1,
-                        'module' => array(
+                        'module' => [
                             'name' => 'wizard_edit',
-                        ),
-                    ),
-                ),
-            ),
-        ),
-        'relations' => array(
+                        ],
+                    ],
+                ],
+            ],
+        ],
+        'relations' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_media.relations',
             'l10n_display' => 'defaultAsReadonly',
             'l10n_mode' => 'exclude',
-            'config' => array(
+            'config' => [
                 'type' => 'inline',
                 'foreign_table' => 'tx_academy_domain_model_relations',
                 'foreign_field' => 'medium',
@@ -329,16 +331,16 @@ return array(
                 'symmetric_field' => 'medium_symmetric',
                 'symmetric_sortby' => 'sorting_symmetric',
                 'maxitems' => 9999,
-                'behaviour' => array(
+                'behaviour' => [
                     'disableMovingChildrenWithParent' => 1,
 //                    'allowLanguageSynchronization' => true,
-                ),
-                'appearance' => array(
+                ],
+                'appearance' => [
                     'collapseAll' => 1,
                     'expandSingle' => 1,
                     'useSortable' => true,
                     'levelLinksPosition' => 'bottom',
-                ),
+                ],
                 'overrideChildTca' => [
                     'columns' => [
                         'type' => [
@@ -385,7 +387,7 @@ return array(
                         ]
                     ],
                 ],
-            ),
-        ),
-    ),
-);
+            ],
+        ],
+    ],
+];

--- a/Configuration/TCA/tx_academy_domain_model_persons.php
+++ b/Configuration/TCA/tx_academy_domain_model_persons.php
@@ -1,10 +1,12 @@
 <?php
-if (!defined('TYPO3_MODE')) {
-    die ('Access denied.');
-}
 
-return array(
-    'ctrl' => array(
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+defined('TYPO3') or die();
+
+return [
+    'ctrl' => [
         'title' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_persons',
         'label' => 'family_name',
         'label_alt' => 'given_name, honorific_prefix, honorific_suffix',
@@ -19,15 +21,15 @@ return array(
         'transOrigPointerField' => 'l10n_parent',
         'transOrigDiffSourceField' => 'l10n_diffsource',
         'delete' => 'deleted',
-        'enablecolumns' => array(
+        'enablecolumns' => [
             'disabled' => 'hidden',
             'starttime' => 'starttime',
             'endtime' => 'endtime',
-        ),
+        ],
         'searchFields' => 'persistent_identifier,given_name,honorific_prefix,additional_name,family_name,honorific_suffix',
-        'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_persons.svg'
-    ),
-    'interface' => array(
+        'iconfile' => ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_persons.svg'
+    ],
+    'interface' => [
         'showRecordFieldList' => '
             sys_language_uid, 
             l10n_parent, 
@@ -41,16 +43,17 @@ return array(
             honorific_suffix, 
             sorting, 
             date_range,
-            image, 
+            image,
+            content_elements,
             expertise, 
             cv, 
             awards, 
             publications, 
             relations
         ',
-    ),
-    'types' => array(
-        '1' => array(
+    ],
+    'types' => [
+        '1' => [
             'showitem' => '
                 --div--;LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_persons.div1,
                     hidden,
@@ -64,6 +67,7 @@ return array(
                     sorting,
                     date_range,
                     image,
+                    content_elements,
                 --div--;LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_persons.div2,
                     relations,
                 --div--;LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_persons.div7,
@@ -73,12 +77,12 @@ return array(
                     l10n_parent,
                     l10n_diffsource,
         '
-        ),
-    ),
-    'palettes' => array(
-        '1' => array('showitem' => ''),
-    ),
-    'columns' => array(
+        ],
+    ],
+    'palettes' => [
+        '1' => ['showitem' => ''],
+    ],
+    'columns' => [
         'sys_language_uid' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
@@ -96,123 +100,123 @@ return array(
                 'default' => 0,
             ]
         ],
-        'l10n_parent' => array(
+        'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.l18n_parent',
-            'config' => array(
+            'config' => [
                 'type' => 'select',
-                'items' => array(
-                    array('', 0),
-                ),
+                'items' => [
+                    ['', 0],
+                ],
                 'foreign_table' => 'tx_academy_domain_model_persons',
                 'foreign_table_where' => 'AND tx_academy_domain_model_persons.pid=###CURRENT_PID### AND tx_academy_domain_model_persons.sys_language_uid IN (-1,0)',
-            ),
-        ),
-        'l10n_diffsource' => array(
-            'config' => array(
+            ],
+        ],
+        'l10n_diffsource' => [
+            'config' => [
                 'type' => 'passthrough',
-            ),
-        ),
-        't3ver_label' => array(
+            ],
+        ],
+        't3ver_label' => [
             'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.versionLabel',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '30',
                 'max' => '255',
-            )
-        ),
-        'hidden' => array(
+            ]
+        ],
+        'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
-            'config' => array(
+            'config' => [
                 'type' => 'check',
-            ),
-        ),
-        'starttime' => array(
+            ],
+        ],
+        'starttime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.starttime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '10',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-            ),
-        ),
-        'endtime' => array(
+            ],
+        ],
+        'endtime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.endtime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '8',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-                'range' => array(
+                'range' => [
                     'upper' => mktime(0, 0, 0, 12, 31, date('Y') + 10),
                     'lower' => mktime(0, 0, 0, date('m') - 1, date('d'), date('Y'))
-                ),
-            ),
-        ),
-        'persistent_identifier' => array(
+                ],
+            ],
+        ],
+        'persistent_identifier' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xlf:tx_academy_domain_model_persons.persistent_identifier',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim',
                 'readOnly' => 1
-            ),
-        ),
-        'given_name' => array(
+            ],
+        ],
+        'given_name' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_persons.given_name',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
-        'additional_name' => array(
+            ],
+        ],
+        'additional_name' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_persons.additional_name',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
-        'family_name' => array(
+            ],
+        ],
+        'family_name' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_persons.family_name',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim,required'
-            ),
-        ),
-        'honorific_prefix' => array(
+            ],
+        ],
+        'honorific_prefix' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_persons.honorific_prefix',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
-        'honorific_suffix' => array(
+            ],
+        ],
+        'honorific_suffix' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_persons.honorific_suffix',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
+            ],
+        ],
         'slug' => [
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_persons.slug',
             'exclude' => 1,
@@ -230,29 +234,29 @@ return array(
                 'default' => ''
             ],
         ],
-        'sorting' => array(
+        'sorting' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_persons.sorting',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
-        'date_range' => array(
+            ],
+        ],
+        'date_range' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xlf:tx_academy_domain_model_persons.date_range',
-            'config' => array(
+            'config' => [
                 'type' => 'inline',
                 'foreign_table' => 'tx_chftime_domain_model_dateranges',
                 'foreign_field' => 'parent',
                 'foreign_table_field' => 'tablename',
                 'minitems' => 0,
                 'maxitems' => 1,
-                'behaviour' => array(
+                'behaviour' => [
                     'disableMovingChildrenWithParent' => 1,
-                ),
-                'appearance' => array(
+                ],
+                'appearance' => [
                     'collapseAll' => 1,
                     'expandSingle' => 1,
                     'newRecordLinkAddTitle' => 1,
@@ -261,37 +265,37 @@ return array(
                     'showSynchronizationLink' => 1,
                     'showPossibleLocalizationRecords' => 1,
                     'showAllLocalizationLink' => 1
-                ),
-            ),
-        ),
-        'image' => array(
+                ],
+            ],
+        ],
+        'image' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_persons.image',
-            'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig('image', array(
-                'appearance' => array(
+            'config' => ExtensionManagementUtility::getFileFieldTCAConfig('image', [
+                'appearance' => [
                     'createNewRelationLinkTitle' => 'LLL:EXT:cms/locallang_ttc.xlf:images.addFileReference'
-                ),
+                ],
                 'minitems' => 0,
                 'maxitems' => 1,
-                'foreign_types' => array(
-                    '0' => array(
+                'foreign_types' => [
+                    '0' => [
                         'showitem' => '
                             --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
                             --palette--;;filePalette'
-                    ),
-                    \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => array(
+                    ],
+                    File::FILETYPE_IMAGE => [
                         'showitem' => '
                             --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
                             --palette--;;filePalette'
-                    ),
-                )
-            ),
+                    ],
+                ]
+            ],
             $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']),
-        ),
-        'page' => array(
+        ],
+        'page' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_persons.page',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'pages',
@@ -299,19 +303,45 @@ return array(
                 'maxitems' => '1',
                 'minitems' => '0',
                 'show_thumbs' => '1',
-                'wizards' => array(
-                    'suggest' => array(
+                'wizards' => [
+                    'suggest' => [
                         'type' => 'suggest',
-                    ),
-                ),
-            ),
-        ),
-        'relations' => array(
+                    ],
+                ],
+            ],
+        ],
+        'content_elements' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xlf:tx_academy_domain_model_persons.content_elements',
+            'config' => [
+                'type' => 'inline',
+                'allowed' => 'tt_content',
+                'foreign_table' => 'tt_content',
+                'foreign_sortby' => 'sorting',
+                'foreign_field' => 'tx_academy_parent',
+                'foreign_table_field' => 'tx_academy_tablename',
+                'minitems' => 0,
+                'maxitems' => 99,
+                'appearance' => [
+                    'collapseAll' => true,
+                    'expandSingle' => true,
+                    'levelLinksPosition' => 'bottom',
+                    'useSortable' => true,
+                    'enabledControls' => [
+                        'info' => false,
+                    ]
+                ],
+                'behaviour' => [
+                    'allowLanguageSynchronization' => true,
+                ],
+            ]
+        ],
+        'relations' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_persons.relations',
             'l10n_display' => 'defaultAsReadonly',
             'l10n_mode' => 'exclude',
-            'config' => array(
+            'config' => [
                 'type' => 'inline',
                 'foreign_table' => 'tx_academy_domain_model_relations',
                 'foreign_field' => 'person',
@@ -319,16 +349,16 @@ return array(
                 'symmetric_field' => 'person_symmetric',
                 'symmetric_sortby' => 'sorting_symmetric',
                 'maxitems' => 9999,
-                'behaviour' => array(
+                'behaviour' => [
                     'disableMovingChildrenWithParent' => 1,
 //                    'allowLanguageSynchronization' => true,
-                ),
-                'appearance' => array(
+                ],
+                'appearance' => [
                     'collapseAll' => 1,
                     'expandSingle' => 1,
                     'useSortable' => true,
                     'levelLinksPosition' => 'bottom',
-                ),
+                ],
                 'overrideChildTca' => [
                     'columns' => [
                         'type' => [
@@ -379,7 +409,7 @@ return array(
                         ]
                     ],
                 ],
-            ),
-        ),
-    ),
-);
+            ],
+        ],
+    ],
+];

--- a/Configuration/TCA/tx_academy_domain_model_products.php
+++ b/Configuration/TCA/tx_academy_domain_model_products.php
@@ -1,10 +1,12 @@
 <?php
-if (!defined('TYPO3_MODE')) {
-    die ('Access denied.');
-}
 
-return array(
-    'ctrl' => array(
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+defined('TYPO3') or die();
+
+return [
+    'ctrl' => [
         'title' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_products',
         'label' => 'title',
         'default_sortby' => 'ORDER BY title ASC',
@@ -17,15 +19,15 @@ return array(
         'transOrigPointerField' => 'l10n_parent',
         'transOrigDiffSourceField' => 'l10n_diffsource',
         'delete' => 'deleted',
-        'enablecolumns' => array(
+        'enablecolumns' => [
             'disabled' => 'hidden',
             'starttime' => 'starttime',
             'endtime' => 'endtime',
-        ),
+        ],
         'searchFields' => 'persistent_identifier,identifier,title,acronym,description',
-        'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_products.svg'
-    ),
-    'interface' => array(
+        'iconfile' => ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_products.svg'
+    ],
+    'interface' => [
         'showRecordFieldList' => '
             sys_language_uid, 
             l10n_parent, 
@@ -39,12 +41,13 @@ return array(
             sorting, 
             page, 
             image,
-            description, 
+            description,
+            content_elements,
             relations
         ',
-    ),
-    'types' => array(
-        '1' => array(
+    ],
+    'types' => [
+        '1' => [
             'showitem' => '
             --div--;LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_products.div1,
                 hidden,
@@ -60,6 +63,7 @@ return array(
             --div--;LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_products.div2,
                 image,
                 description,
+                content_elements,
             --div--;LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_products.div3,
                 relations,
             --div--;LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_products.div5,
@@ -69,12 +73,12 @@ return array(
                 l10n_parent,
                 l10n_diffsource,
         '
-        ),
-    ),
-    'palettes' => array(
-        '1' => array('showitem' => ''),
-    ),
-    'columns' => array(
+        ],
+    ],
+    'palettes' => [
+        '1' => ['showitem' => ''],
+    ],
+    'columns' => [
         'sys_language_uid' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
@@ -92,115 +96,115 @@ return array(
                 'default' => 0,
             ]
         ],
-        'l10n_parent' => array(
+        'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
             'exclude' => 1,
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.l18n_parent',
-            'config' => array(
+            'config' => [
                 'type' => 'select',
-                'items' => array(
-                    array('', 0),
-                ),
+                'items' => [
+                    ['', 0],
+                ],
                 'foreign_table' => 'tx_academy_domain_model_products',
                 'foreign_table_where' => 'AND tx_academy_domain_model_products.pid=###CURRENT_PID### AND tx_academy_domain_model_products.sys_language_uid IN (-1,0)',
-            ),
-        ),
-        'l10n_diffsource' => array(
-            'config' => array(
+            ],
+        ],
+        'l10n_diffsource' => [
+            'config' => [
                 'type' => 'passthrough',
-            ),
-        ),
-        't3ver_label' => array(
+            ],
+        ],
+        't3ver_label' => [
             'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.versionLabel',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '30',
                 'max' => '255',
-            )
-        ),
-        'hidden' => array(
+            ]
+        ],
+        'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
-            'config' => array(
+            'config' => [
                 'type' => 'check',
-            ),
-        ),
-        'starttime' => array(
+            ],
+        ],
+        'starttime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.starttime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '10',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-            ),
-        ),
-        'endtime' => array(
+            ],
+        ],
+        'endtime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.endtime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '8',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-                'range' => array(
+                'range' => [
                     'upper' => mktime(0, 0, 0, 12, 31, date('Y') + 10),
                     'lower' => mktime(0, 0, 0, date('m') - 1, date('d'), date('Y'))
-                ),
-            ),
-        ),
-        'persistent_identifier' => array(
+                ],
+            ],
+        ],
+        'persistent_identifier' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xlf:tx_academy_domain_model_products.persistent_identifier',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim',
                 'readOnly' => 1
-            ),
-        ),
-        'identifier' => array(
+            ],
+        ],
+        'identifier' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_products.identifier',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
-        'title' => array(
+            ],
+        ],
+        'title' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_products.title',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim,required'
-            ),
-        ),
-        'acronym' => array(
+            ],
+        ],
+        'acronym' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_products.acronym',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
-        'version' => array(
+            ],
+        ],
+        'version' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_products.version',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
+            ],
+        ],
         'slug' => [
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_products.slug',
             'exclude' => 1,
@@ -218,29 +222,29 @@ return array(
                 'default' => ''
             ],
         ],
-        'sorting' => array(
+        'sorting' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_products.sorting',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
-        'date_range' => array(
+            ],
+        ],
+        'date_range' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xlf:tx_academy_domain_model_products.date_range',
-            'config' => array(
+            'config' => [
                 'type' => 'inline',
                 'foreign_table' => 'tx_chftime_domain_model_dateranges',
                 'foreign_field' => 'parent',
                 'foreign_table_field' => 'tablename',
                 'minitems' => 0,
                 'maxitems' => 1,
-                'behaviour' => array(
+                'behaviour' => [
                     'disableMovingChildrenWithParent' => 1,
-                ),
-                'appearance' => array(
+                ],
+                'appearance' => [
                     'collapseAll' => 1,
                     'expandSingle' => 1,
                     'newRecordLinkAddTitle' => 1,
@@ -249,13 +253,13 @@ return array(
                     'showSynchronizationLink' => 1,
                     'showPossibleLocalizationRecords' => 1,
                     'showAllLocalizationLink' => 1
-                ),
-            ),
-        ),
-        'page' => array(
+                ],
+            ],
+        ],
+        'page' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_products.page',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'pages',
@@ -265,55 +269,81 @@ return array(
                 'show_thumbs' => '1',
                 'eval' => 'int',
                 'default' => 0,
-                'wizards' => array(
-                    'suggest' => array(
+                'wizards' => [
+                    'suggest' => [
                         'type' => 'suggest',
-                    ),
-                ),
-            ),
-        ),
-        'image' => array(
+                    ],
+                ],
+            ],
+        ],
+        'image' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_products.image',
-            'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig('image', array(
-                'appearance' => array(
+            'config' => ExtensionManagementUtility::getFileFieldTCAConfig('image', [
+                'appearance' => [
                     'createNewRelationLinkTitle' => 'LLL:EXT:cms/locallang_ttc.xlf:images.addFileReference'
-                ),
+                ],
                 'minitems' => 0,
                 'maxitems' => 1,
-                'foreign_types' => array(
-                    '0' => array(
+                'foreign_types' => [
+                    '0' => [
                         'showitem' => '
                             --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
                             --palette--;;filePalette'
-                    ),
-                    \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => array(
+                    ],
+                    File::FILETYPE_IMAGE => [
                         'showitem' => '
                             --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
                             --palette--;;filePalette'
-                    ),
-                )
-            ),
+                    ],
+                ]
+            ],
             $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']),
-        ),
-        'description' => array(
+        ],
+        'description' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_products.description',
-            'config' => array(
+            'config' => [
                 'type' => 'text',
                 'cols' => 40,
                 'rows' => 15,
                 'eval' => 'trim',
                 'softref' => 'rtehtmlarea_images,typolink_tag,images,email[subst],url',
                 'enableRichtext' => true,
-            ),
-        ),
-        'relations' => array(
+            ],
+        ],
+        'content_elements' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xlf:tx_academy_domain_model_products.content_elements',
+            'config' => [
+                'type' => 'inline',
+                'allowed' => 'tt_content',
+                'foreign_table' => 'tt_content',
+                'foreign_sortby' => 'sorting',
+                'foreign_field' => 'tx_academy_parent',
+                'foreign_table_field' => 'tx_academy_tablename',
+                'minitems' => 0,
+                'maxitems' => 99,
+                'appearance' => [
+                    'collapseAll' => true,
+                    'expandSingle' => true,
+                    'levelLinksPosition' => 'bottom',
+                    'useSortable' => true,
+                    'enabledControls' => [
+                        'info' => false,
+                    ]
+                ],
+                'behaviour' => [
+                    'allowLanguageSynchronization' => true,
+                ],
+            ]
+        ],
+        'relations' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_products.relations',
             'l10n_display' => 'defaultAsReadonly',
             'l10n_mode' => 'exclude',
-            'config' => array(
+            'config' => [
                 'type' => 'inline',
                 'foreign_table' => 'tx_academy_domain_model_relations',
                 'foreign_field' => 'product',
@@ -321,16 +351,16 @@ return array(
                 'symmetric_field' => 'product_symmetric',
                 'symmetric_sortby' => 'sorting_symmetric',
                 'maxitems' => 9999,
-                'behaviour' => array(
+                'behaviour' => [
                     'disableMovingChildrenWithParent' => 1,
 //                    'allowLanguageSynchronization' => true,
-                ),
-                'appearance' => array(
+                ],
+                'appearance' => [
                     'collapseAll' => 1,
                     'expandSingle' => 1,
                     'useSortable' => true,
                     'levelLinksPosition' => 'bottom',
-                ),
+                ],
                 'overrideChildTca' => [
                     'columns' => [
                         'type' => [
@@ -377,7 +407,7 @@ return array(
                         ]
                     ],
                 ],
-            ),
-        ),
-    ),
-);
+            ],
+        ],
+    ],
+];

--- a/Configuration/TCA/tx_academy_domain_model_projects.php
+++ b/Configuration/TCA/tx_academy_domain_model_projects.php
@@ -1,10 +1,12 @@
 <?php
-if (!defined('TYPO3_MODE')) {
-    die ('Access denied.');
-}
 
-return array(
-    'ctrl' => array(
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+defined('TYPO3') or die();
+
+return [
+    'ctrl' => [
         'title' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_projects',
         'label' => 'title',
         'default_sortby' => 'ORDER BY title ASC',
@@ -17,15 +19,15 @@ return array(
         'transOrigPointerField' => 'l10n_parent',
         'transOrigDiffSourceField' => 'l10n_diffsource',
         'delete' => 'deleted',
-        'enablecolumns' => array(
+        'enablecolumns' => [
             'disabled' => 'hidden',
             'starttime' => 'starttime',
             'endtime' => 'endtime',
-        ),
+        ],
         'searchFields' => 'persistent_identifier,identifier,title,acronym,description',
-        'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_projects.svg'
-    ),
-    'interface' => array(
+        'iconfile' => ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_projects.svg'
+    ],
+    'interface' => [
         'showRecordFieldList' => '
             sys_language_uid, 
             l10n_parent, 
@@ -38,12 +40,13 @@ return array(
             sorting, 
             page, 
             image,
-            description, 
+            description,
+            content_elements, 
             relations
         ',
-    ),
-    'types' => array(
-        '1' => array(
+    ],
+    'types' => [
+        '1' => [
             'showitem' => '
             --div--;LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_projects.div1,
                 hidden,
@@ -58,6 +61,7 @@ return array(
             --div--;LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_projects.div2,
                 image,
                 description;;;richtext[cut|copy|paste|formatblock|textcolor|bold|italic|underline|left|center|right|orderedlist|unorderedlist|outdent|indent|link|table|image|line|chMode]:rte_transform[mode=ts_css|imgpath=uploads/tx_academy/],
+                content_elements,
             --div--;LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_projects.div3,
                 relations,
             --div--;LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_projects.div5,
@@ -67,12 +71,12 @@ return array(
                 l10n_parent,
                 l10n_diffsource
         '
-        ),
-    ),
-    'palettes' => array(
-        '1' => array('showitem' => ''),
-    ),
-    'columns' => array(
+        ],
+    ],
+    'palettes' => [
+        '1' => ['showitem' => ''],
+    ],
+    'columns' => [
         'sys_language_uid' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
@@ -90,106 +94,106 @@ return array(
                 'default' => 0,
             ]
         ],
-        'l10n_parent' => array(
+        'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
             'exclude' => 1,
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.l18n_parent',
-            'config' => array(
+            'config' => [
                 'type' => 'select',
-                'items' => array(
-                    array('', 0),
-                ),
+                'items' => [
+                    ['', 0],
+                ],
                 'foreign_table' => 'tx_academy_domain_model_projects',
                 'foreign_table_where' => 'AND tx_academy_domain_model_projects.pid=###CURRENT_PID### AND tx_academy_domain_model_projects.sys_language_uid IN (-1,0)',
-            ),
-        ),
-        'l10n_diffsource' => array(
-            'config' => array(
+            ],
+        ],
+        'l10n_diffsource' => [
+            'config' => [
                 'type' => 'passthrough',
-            ),
-        ),
-        't3ver_label' => array(
+            ],
+        ],
+        't3ver_label' => [
             'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.versionLabel',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '30',
                 'max' => '255',
-            )
-        ),
-        'hidden' => array(
+            ]
+        ],
+        'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
-            'config' => array(
+            'config' => [
                 'type' => 'check',
-            ),
-        ),
-        'starttime' => array(
+            ],
+        ],
+        'starttime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.starttime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '10',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-            ),
-        ),
-        'endtime' => array(
+            ],
+        ],
+        'endtime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.endtime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '8',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-                'range' => array(
+                'range' => [
                     'upper' => mktime(0, 0, 0, 12, 31, date('Y') + 10),
                     'lower' => mktime(0, 0, 0, date('m') - 1, date('d'), date('Y'))
-                ),
-            ),
-        ),
-        'persistent_identifier' => array(
+                ],
+            ],
+        ],
+        'persistent_identifier' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xlf:tx_academy_domain_model_projects.persistent_identifier',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim',
                 'readOnly' => 1
-            ),
-        ),
-        'identifier' => array(
+            ],
+        ],
+        'identifier' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_projects.identifier',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
-        'title' => array(
+            ],
+        ],
+        'title' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_projects.title',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim,required'
-            ),
-        ),
-        'acronym' => array(
+            ],
+        ],
+        'acronym' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_projects.acronym',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
+            ],
+        ],
         'slug' => [
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_services.slug',
             'exclude' => 1,
@@ -207,29 +211,29 @@ return array(
                 'default' => ''
             ],
         ],
-        'sorting' => array(
+        'sorting' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_projects.sorting',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
-        'date_range' => array(
+            ],
+        ],
+        'date_range' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xlf:tx_academy_domain_model_projects.date_range',
-            'config' => array(
+            'config' => [
                 'type' => 'inline',
                 'foreign_table' => 'tx_chftime_domain_model_dateranges',
                 'foreign_field' => 'parent',
                 'foreign_table_field' => 'tablename',
                 'minitems' => 0,
                 'maxitems' => 1,
-                'behaviour' => array(
+                'behaviour' => [
                     'disableMovingChildrenWithParent' => 1,
-                ),
-                'appearance' => array(
+                ],
+                'appearance' => [
                     'collapseAll' => 1,
                     'expandSingle' => 1,
                     'newRecordLinkAddTitle' => 1,
@@ -238,13 +242,13 @@ return array(
                     'showSynchronizationLink' => 1,
                     'showPossibleLocalizationRecords' => 1,
                     'showAllLocalizationLink' => 1
-                ),
-            ),
-        ),
-        'page' => array(
+                ],
+            ],
+        ],
+        'page' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_projects.page',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'pages',
@@ -254,55 +258,81 @@ return array(
                 'show_thumbs' => '1',
                 'eval' => 'int',
                 'default' => 0,
-                'wizards' => array(
-                    'suggest' => array(
+                'wizards' => [
+                    'suggest' => [
                         'type' => 'suggest',
-                    ),
-                ),
-            ),
-        ),
-        'image' => array(
+                    ],
+                ],
+            ],
+        ],
+        'image' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_projects.image',
-            'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig('image', array(
-                'appearance' => array(
+            'config' => ExtensionManagementUtility::getFileFieldTCAConfig('image', [
+                'appearance' => [
                     'createNewRelationLinkTitle' => 'LLL:EXT:cms/locallang_ttc.xlf:images.addFileReference'
-                ),
+                ],
                 'minitems' => 0,
                 'maxitems' => 1,
-                'foreign_types' => array(
-                    '0' => array(
+                'foreign_types' => [
+                    '0' => [
                         'showitem' => '
                             --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
                             --palette--;;filePalette'
-                    ),
-                    \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => array(
+                    ],
+                    File::FILETYPE_IMAGE => [
                         'showitem' => '
                             --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
                             --palette--;;filePalette'
-                    ),
-                )
-            ),
+                    ],
+                ]
+            ],
             $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']),
-        ),
-        'description' => array(
+        ],
+        'description' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_projects.description',
-            'config' => array(
+            'config' => [
                 'type' => 'text',
                 'cols' => 40,
                 'rows' => 15,
                 'eval' => 'trim',
                 'softref' => 'rtehtmlarea_images,typolink_tag,images,email[subst],url',
                 'enableRichtext' => true,
-            ),
-        ),
-        'relations' => array(
+            ],
+        ],
+        'content_elements' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xlf:tx_academy_domain_model_projects.content_elements',
+            'config' => [
+                'type' => 'inline',
+                'allowed' => 'tt_content',
+                'foreign_table' => 'tt_content',
+                'foreign_sortby' => 'sorting',
+                'foreign_field' => 'tx_academy_parent',
+                'foreign_table_field' => 'tx_academy_tablename',
+                'minitems' => 0,
+                'maxitems' => 99,
+                'appearance' => [
+                    'collapseAll' => true,
+                    'expandSingle' => true,
+                    'levelLinksPosition' => 'bottom',
+                    'useSortable' => true,
+                    'enabledControls' => [
+                        'info' => false,
+                    ]
+                ],
+                'behaviour' => [
+                    'allowLanguageSynchronization' => true,
+                ],
+            ]
+        ],
+        'relations' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_projects.relations',
             'l10n_display' => 'defaultAsReadonly',
             'l10n_mode' => 'exclude',
-            'config' => array(
+            'config' => [
                 'type' => 'inline',
                 'foreign_table' => 'tx_academy_domain_model_relations',
                 'foreign_field' => 'project',
@@ -310,16 +340,16 @@ return array(
                 'symmetric_field' => 'project_symmetric',
                 'symmetric_sortby' => 'sorting_symmetric',
                 'maxitems' => 9999,
-                'behaviour' => array(
+                'behaviour' => [
                     'disableMovingChildrenWithParent' => 1,
 //                    'allowLanguageSynchronization' => true,
-                ),
-                'appearance' => array(
+                ],
+                'appearance' => [
                     'collapseAll' => 1,
                     'expandSingle' => 1,
                     'useSortable' => true,
                     'levelLinksPosition' => 'bottom',
-                ),
+                ],
                 'overrideChildTca' => [
                     'columns' => [
                         'type' => [
@@ -374,7 +404,7 @@ return array(
                         ]
                     ],
                 ],
-            ),
-        ),
-    ),
-);
+            ],
+        ],
+    ],
+];

--- a/Configuration/TCA/tx_academy_domain_model_publications.php
+++ b/Configuration/TCA/tx_academy_domain_model_publications.php
@@ -1,10 +1,12 @@
 <?php
-if (!defined('TYPO3_MODE')) {
-    die ('Access denied.');
-}
 
-return array(
-    'ctrl' => array(
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+defined('TYPO3') or die();
+
+return [
+    'ctrl' => [
         'title' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_publications',
         'label' => 'title',
         'default_sortby' => 'ORDER BY title ASC',
@@ -17,15 +19,15 @@ return array(
         'transOrigPointerField' => 'l10n_parent',
         'transOrigDiffSourceField' => 'l10n_diffsource',
         'delete' => 'deleted',
-        'enablecolumns' => array(
+        'enablecolumns' => [
             'disabled' => 'hidden',
             'starttime' => 'starttime',
             'endtime' => 'endtime',
-        ),
+        ],
         'searchFields' => 'persistent_identifier,identifier,title,acronym,description',
-        'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_publications.svg'
-    ),
-    'interface' => array(
+        'iconfile' => ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_publications.svg'
+    ],
+    'interface' => [
         'showRecordFieldList' => '
             sys_language_uid, 
             l10n_parent, 
@@ -48,13 +50,14 @@ return array(
             date_range,
             page, 
             image,
-            description, 
+            description,
+            content_elements,
             bibliographic_note,
             relations,
         ',
-    ),
-    'types' => array(
-        '1' => array(
+    ],
+    'types' => [
+        '1' => [
             'showitem' => '
             --div--;LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_publications.div1,
                 hidden,
@@ -80,6 +83,7 @@ return array(
                 image,
                 description,
                 bibliographic_note,
+                content_elements,
             --div--;LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_publications.div3,
                 relations,
             --div--;LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_publications.div5,
@@ -89,12 +93,12 @@ return array(
                 l10n_parent,
                 l10n_diffsource,
         '
-        ),
-    ),
-    'palettes' => array(
-        '1' => array('showitem' => ''),
-    ),
-    'columns' => array(
+        ],
+    ],
+    'palettes' => [
+        '1' => ['showitem' => ''],
+    ],
+    'columns' => [
         'sys_language_uid' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
@@ -112,187 +116,187 @@ return array(
                 'default' => 0,
             ]
         ],
-        'l10n_parent' => array(
+        'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
             'exclude' => 1,
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.l18n_parent',
-            'config' => array(
+            'config' => [
                 'type' => 'select',
-                'items' => array(
-                    array('', 0),
-                ),
+                'items' => [
+                    ['', 0],
+                ],
                 'foreign_table' => 'tx_academy_domain_model_publications',
                 'foreign_table_where' => 'AND tx_academy_domain_model_publications.pid=###CURRENT_PID### AND tx_academy_domain_model_publications.sys_language_uid IN (-1,0)',
-            ),
-        ),
-        'l10n_diffsource' => array(
-            'config' => array(
+            ],
+        ],
+        'l10n_diffsource' => [
+            'config' => [
                 'type' => 'passthrough',
-            ),
-        ),
-        't3ver_label' => array(
+            ],
+        ],
+        't3ver_label' => [
             'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.versionLabel',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '30',
                 'max' => '255',
-            )
-        ),
-        'hidden' => array(
+            ]
+        ],
+        'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
-            'config' => array(
+            'config' => [
                 'type' => 'check',
-            ),
-        ),
-        'starttime' => array(
+            ],
+        ],
+        'starttime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.starttime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '10',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-            ),
-        ),
-        'endtime' => array(
+            ],
+        ],
+        'endtime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.endtime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '8',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-                'range' => array(
+                'range' => [
                     'upper' => mktime(0, 0, 0, 12, 31, date('Y') + 10),
                     'lower' => mktime(0, 0, 0, date('m') - 1, date('d'), date('Y'))
-                ),
-            ),
-        ),
-        'persistent_identifier' => array(
+                ],
+            ],
+        ],
+        'persistent_identifier' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xlf:tx_academy_domain_model_publications.persistent_identifier',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim',
                 'readOnly' => 1
-            ),
-        ),
-        'identifier' => array(
+            ],
+        ],
+        'identifier' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_publications.identifier',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
-        'title' => array(
+            ],
+        ],
+        'title' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_publications.title',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
-        'subtitle' => array(
+            ],
+        ],
+        'subtitle' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_publications.subtitle',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
-        'abbreviation' => array(
+            ],
+        ],
+        'abbreviation' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_publications.abbreviation',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim, required'
-            ),
-        ),
-        'volume' => array(
+            ],
+        ],
+        'volume' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_publications.volume',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
-        'number' => array(
+            ],
+        ],
+        'number' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_publications.number',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
-        'issue' => array(
+            ],
+        ],
+        'issue' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_publications.issue',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
-        'edition' => array(
+            ],
+        ],
+        'edition' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_publications.edition',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
-        'series' => array(
+            ],
+        ],
+        'series' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_publications.series',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
-        'start_page' => array(
+            ],
+        ],
+        'start_page' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_publications.start_page',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
-        'end_page' => array(
+            ],
+        ],
+        'end_page' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_publications.end_page',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
-        'total_pages' => array(
+            ],
+        ],
+        'total_pages' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_publications.total_pages',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
+            ],
+        ],
         'slug' => [
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_publications.slug',
             'exclude' => 1,
@@ -310,20 +314,20 @@ return array(
                 'default' => ''
             ],
         ],
-        'date_range' => array(
+        'date_range' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xlf:tx_academy_domain_model_publications.date_range',
-            'config' => array(
+            'config' => [
                 'type' => 'inline',
                 'foreign_table' => 'tx_chftime_domain_model_dateranges',
                 'foreign_field' => 'parent',
                 'foreign_table_field' => 'tablename',
                 'minitems' => 0,
                 'maxitems' => 1,
-                'behaviour' => array(
+                'behaviour' => [
                     'disableMovingChildrenWithParent' => 1,
-                ),
-                'appearance' => array(
+                ],
+                'appearance' => [
                     'collapseAll' => 1,
                     'expandSingle' => 1,
                     'newRecordLinkAddTitle' => 1,
@@ -332,13 +336,13 @@ return array(
                     'showSynchronizationLink' => 1,
                     'showPossibleLocalizationRecords' => 1,
                     'showAllLocalizationLink' => 1
-                ),
-            ),
-        ),
-        'page' => array(
+                ],
+            ],
+        ],
+        'page' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_publications.page',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'pages',
@@ -348,67 +352,93 @@ return array(
                 'show_thumbs' => '1',
                 'eval' => 'int',
                 'default' => 0,
-                'wizards' => array(
-                    'suggest' => array(
+                'wizards' => [
+                    'suggest' => [
                         'type' => 'suggest',
-                    ),
-                ),
-            ),
-        ),
-        'image' => array(
+                    ],
+                ],
+            ],
+        ],
+        'image' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_publications.image',
-            'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig('image', array(
-                'appearance' => array(
+            'config' => ExtensionManagementUtility::getFileFieldTCAConfig('image', [
+                'appearance' => [
                     'createNewRelationLinkTitle' => 'LLL:EXT:cms/locallang_ttc.xlf:images.addFileReference'
-                ),
+                ],
                 'minitems' => 0,
                 'maxitems' => 1,
-                'foreign_types' => array(
-                    '0' => array(
+                'foreign_types' => [
+                    '0' => [
                         'showitem' => '
                             --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
                             --palette--;;filePalette'
-                    ),
-                    \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => array(
+                    ],
+                    File::FILETYPE_IMAGE => [
                         'showitem' => '
                             --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
                             --palette--;;filePalette'
-                    ),
-                )
-            ),
+                    ],
+                ]
+            ],
             $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']),
-        ),
-        'description' => array(
+        ],
+        'description' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_publications.description',
-            'config' => array(
+            'config' => [
                 'type' => 'text',
                 'cols' => 40,
                 'rows' => 15,
                 'eval' => 'trim',
                 'softref' => 'rtehtmlarea_images,typolink_tag,images,email[subst],url',
                 'enableRichtext' => true,
-            ),
-        ),
-        'bibliographic_note' => array(
+            ],
+        ],
+        'bibliographic_note' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_publications.bibliographic_note',
-            'config' => array(
+            'config' => [
                 'type' => 'text',
                 'cols' => 40,
                 'rows' => 15,
                 'eval' => 'trim',
                 'softref' => 'rtehtmlarea_images,typolink_tag,images,email[subst],url',
                 'enableRichtext' => true,
-            ),
-        ),
-        'relations' => array(
+            ],
+        ],
+        'content_elements' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xlf:tx_academy_domain_model_publications.content_elements',
+            'config' => [
+                'type' => 'inline',
+                'allowed' => 'tt_content',
+                'foreign_table' => 'tt_content',
+                'foreign_sortby' => 'sorting',
+                'foreign_field' => 'tx_academy_parent',
+                'foreign_table_field' => 'tx_academy_tablename',
+                'minitems' => 0,
+                'maxitems' => 99,
+                'appearance' => [
+                    'collapseAll' => true,
+                    'expandSingle' => true,
+                    'levelLinksPosition' => 'bottom',
+                    'useSortable' => true,
+                    'enabledControls' => [
+                        'info' => false,
+                    ]
+                ],
+                'behaviour' => [
+                    'allowLanguageSynchronization' => true,
+                ],
+            ]
+        ],
+        'relations' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_publications.relations',
             'l10n_display' => 'defaultAsReadonly',
             'l10n_mode' => 'exclude',
-            'config' => array(
+            'config' => [
                 'type' => 'inline',
                 'foreign_table' => 'tx_academy_domain_model_relations',
                 'foreign_field' => 'publication',
@@ -416,16 +446,16 @@ return array(
                 'symmetric_field' => 'publication_symmetric',
                 'symmetric_sortby' => 'sorting_symmetric',
                 'maxitems' => 9999,
-                'behaviour' => array(
+                'behaviour' => [
                     'disableMovingChildrenWithParent' => 1,
 //                    'allowLanguageSynchronization' => true,
-                ),
-                'appearance' => array(
+                ],
+                'appearance' => [
                     'collapseAll' => 1,
                     'expandSingle' => 1,
                     'useSortable' => true,
                     'levelLinksPosition' => 'bottom',
-                ),
+                ],
                 'overrideChildTca' => [
                     'columns' => [
                         'type' => [
@@ -472,7 +502,7 @@ return array(
                         ]
                     ],
                 ],
-            ),
-        ),
-    ),
-);
+            ],
+        ],
+    ],
+];

--- a/Configuration/TCA/tx_academy_domain_model_relations.php
+++ b/Configuration/TCA/tx_academy_domain_model_relations.php
@@ -1,10 +1,11 @@
 <?php
-if (!defined('TYPO3_MODE')) {
-    die ('Access denied.');
-}
 
-return array(
-    'ctrl' => array(
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+defined('TYPO3') or die();
+
+return [
+    'ctrl' => [
         'title' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_relations',
         'label' => 'type',
         // this call is for list view
@@ -23,14 +24,14 @@ return array(
         'transOrigPointerField' => 'l10n_parent',
         'transOrigDiffSourceField' => 'l10n_diffsource',
         'delete' => 'deleted',
-        'enablecolumns' => array(
+        'enablecolumns' => [
             'disabled' => 'hidden',
             'starttime' => 'starttime',
             'endtime' => 'endtime',
-        ),
-        'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_relations.svg'
-    ),
-    'interface' => array(
+        ],
+        'iconfile' => ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_relations.svg'
+    ],
+    'interface' => [
         'showRecordFieldList' => '
             sys_language_uid, 
             l10n_parent, 
@@ -64,76 +65,76 @@ return array(
             sorting,
             sorting_symmetric,
         ',
-    ),
-    'types' => array(
+    ],
+    'types' => [
 
-        '0' => array('showitem' => 'type'),
+        '0' => ['showitem' => 'type'],
 
-        '10' => array('showitem' => 'type,person,hcard,date_range'),
-        '11' => array('showitem' => 'type,role,role_freetext,person,project,date_range,freetext'),
-        '12' => array('showitem' => 'type,role,role_freetext,person,unit,date_range,freetext'),
-        '13' => array('showitem' => 'type,role,role_freetext,person,event,date_range,freetext'),
-        '14' => array('showitem' => 'type,role,role_freetext,person,news,date_range,freetext'),
-        '15' => array('showitem' => 'type,role,role_freetext,person,medium,date_range,freetext'),
-        '16' => array('showitem' => 'type,role,role_freetext,person,person_symmetric,date_range,freetext'),
+        '10' => ['showitem' => 'type,person,hcard,date_range'],
+        '11' => ['showitem' => 'type,role,role_freetext,person,project,date_range,freetext'],
+        '12' => ['showitem' => 'type,role,role_freetext,person,unit,date_range,freetext'],
+        '13' => ['showitem' => 'type,role,role_freetext,person,event,date_range,freetext'],
+        '14' => ['showitem' => 'type,role,role_freetext,person,news,date_range,freetext'],
+        '15' => ['showitem' => 'type,role,role_freetext,person,medium,date_range,freetext'],
+        '16' => ['showitem' => 'type,role,role_freetext,person,person_symmetric,date_range,freetext'],
 
-        '20' => array('showitem' => 'type,role,role_freetext,project,hcard,date_range'),
-        '21' => array('showitem' => 'type,role,role_freetext,project,unit,date_range,freetext'),
-        '22' => array('showitem' => 'type,role,role_freetext,project,news,date_range,freetext'),
-        '23' => array('showitem' => 'type,role,role_freetext,project,event,date_range,freetext'),
-        '24' => array('showitem' => 'type,role,role_freetext,project,medium,date_range,freetext'),
-        '25' => array('showitem' => 'type,role_freetext,project,freetext,date_range'),
-        '26' => array('showitem' => 'type,role,role_freetext,project,project_symmetric,date_range,freetext'),
+        '20' => ['showitem' => 'type,role,role_freetext,project,hcard,date_range'],
+        '21' => ['showitem' => 'type,role,role_freetext,project,unit,date_range,freetext'],
+        '22' => ['showitem' => 'type,role,role_freetext,project,news,date_range,freetext'],
+        '23' => ['showitem' => 'type,role,role_freetext,project,event,date_range,freetext'],
+        '24' => ['showitem' => 'type,role,role_freetext,project,medium,date_range,freetext'],
+        '25' => ['showitem' => 'type,role_freetext,project,freetext,date_range'],
+        '26' => ['showitem' => 'type,role,role_freetext,project,project_symmetric,date_range,freetext'],
 
-        '30' => array('showitem' => 'type,unit,hcard,date_range'),
-        '31' => array('showitem' => 'type,role,role_freetext,unit,freetext,date_range'),
-        '32' => array('showitem' => 'type,role,unit,unit_symmetric,date_range,freetext'),
-        '33' => array('showitem' => 'type,role,unit,news,date_range,freetext'),
-        '34' => array('showitem' => 'type,role,unit,event,date_range,freetext'),
-        '35' => array('showitem' => 'type,role,unit,medium,date_range,freetext'),
+        '30' => ['showitem' => 'type,unit,hcard,date_range'],
+        '31' => ['showitem' => 'type,role,role_freetext,unit,freetext,date_range'],
+        '32' => ['showitem' => 'type,role,unit,unit_symmetric,date_range,freetext'],
+        '33' => ['showitem' => 'type,role,unit,news,date_range,freetext'],
+        '34' => ['showitem' => 'type,role,unit,event,date_range,freetext'],
+        '35' => ['showitem' => 'type,role,unit,medium,date_range,freetext'],
 
-        '40' => array('showitem' => 'type,news,hcard,date_range'),
-        '41' => array('showitem' => 'type,news,event,date_range,freetext'),
-        '42' => array('showitem' => 'type,news,medium,date_range,freetext'),
-        '43' => array('showitem' => 'type,news,news_symmetric,date_range,freetext'),
+        '40' => ['showitem' => 'type,news,hcard,date_range'],
+        '41' => ['showitem' => 'type,news,event,date_range,freetext'],
+        '42' => ['showitem' => 'type,news,medium,date_range,freetext'],
+        '43' => ['showitem' => 'type,news,news_symmetric,date_range,freetext'],
 
-        '50' => array('showitem' => 'type,event,hcard,date_range'),
-        '51' => array('showitem' => 'type,event,medium,date_range,freetext'),
-        '52' => array('showitem' => 'type,event,event_symmetric,date_range,freetext'),
+        '50' => ['showitem' => 'type,event,hcard,date_range'],
+        '51' => ['showitem' => 'type,event,medium,date_range,freetext'],
+        '52' => ['showitem' => 'type,event,event_symmetric,date_range,freetext'],
 
-        '60' => array('showitem' => 'type,medium,medium_symmetric,date_range,freetext'),
+        '60' => ['showitem' => 'type,medium,medium_symmetric,date_range,freetext'],
 
-        '70' => array('showitem' => 'type,role,role_freetext,person,product,date_range,freetext'),
-        '71' => array('showitem' => 'type,role,role_freetext,project,product,date_range,freetext'),
-        '72' => array('showitem' => 'type,role,role_freetext,unit,product,date_range,freetext'),
-        '73' => array('showitem' => 'type,role,role_freetext,medium,product,date_range,freetext'),
-        '74' => array('showitem' => 'type,role,role_freetext,news,product,date_range,freetext'),
-        '75' => array('showitem' => 'type,role,role_freetext,event,product,date_range,freetext'),
-        '76' => array('showitem' => 'type,role,role_freetext,service,product,date_range,freetext'),
-        '77' => array('showitem' => 'type,role,role_freetext,publication,product,date_range,freetext'),
-        '78' => array('showitem' => 'type,role,role_freetext,product,product_symmetric,date_range,freetext'),
+        '70' => ['showitem' => 'type,role,role_freetext,person,product,date_range,freetext'],
+        '71' => ['showitem' => 'type,role,role_freetext,project,product,date_range,freetext'],
+        '72' => ['showitem' => 'type,role,role_freetext,unit,product,date_range,freetext'],
+        '73' => ['showitem' => 'type,role,role_freetext,medium,product,date_range,freetext'],
+        '74' => ['showitem' => 'type,role,role_freetext,news,product,date_range,freetext'],
+        '75' => ['showitem' => 'type,role,role_freetext,event,product,date_range,freetext'],
+        '76' => ['showitem' => 'type,role,role_freetext,service,product,date_range,freetext'],
+        '77' => ['showitem' => 'type,role,role_freetext,publication,product,date_range,freetext'],
+        '78' => ['showitem' => 'type,role,role_freetext,product,product_symmetric,date_range,freetext'],
 
-        '80' => array('showitem' => 'type,role,role_freetext,person,service,date_range,freetext'),
-        '81' => array('showitem' => 'type,role,role_freetext,project,service,date_range,freetext'),
-        '82' => array('showitem' => 'type,role,role_freetext,unit,service,date_range,freetext'),
-        '83' => array('showitem' => 'type,role,role_freetext,medium,service,date_range,freetext'),
-        '84' => array('showitem' => 'type,role,role_freetext,news,service,date_range,freetext'),
-        '85' => array('showitem' => 'type,role,role_freetext,event,service,date_range,freetext'),
-        '86' => array('showitem' => 'type,role,role_freetext,publication,service,date_range,freetext'),
-        '87' => array('showitem' => 'type,role,role_freetext,service,service_symmetric,date_range,freetext'),
+        '80' => ['showitem' => 'type,role,role_freetext,person,service,date_range,freetext'],
+        '81' => ['showitem' => 'type,role,role_freetext,project,service,date_range,freetext'],
+        '82' => ['showitem' => 'type,role,role_freetext,unit,service,date_range,freetext'],
+        '83' => ['showitem' => 'type,role,role_freetext,medium,service,date_range,freetext'],
+        '84' => ['showitem' => 'type,role,role_freetext,news,service,date_range,freetext'],
+        '85' => ['showitem' => 'type,role,role_freetext,event,service,date_range,freetext'],
+        '86' => ['showitem' => 'type,role,role_freetext,publication,service,date_range,freetext'],
+        '87' => ['showitem' => 'type,role,role_freetext,service,service_symmetric,date_range,freetext'],
 
-        '90' => array('showitem' => 'type,role,role_freetext,person,publication,date_range,freetext'),
-        '91' => array('showitem' => 'type,role,role_freetext,project,publication,date_range,freetext'),
-        '92' => array('showitem' => 'type,role,role_freetext,unit,publication,date_range,freetext'),
-        '93' => array('showitem' => 'type,role,role_freetext,medium,publication,date_range,freetext'),
-        '94' => array('showitem' => 'type,role,role_freetext,news,publication,date_range,freetext'),
-        '95' => array('showitem' => 'type,role,role_freetext,event,publication,date_range,freetext'),
-        '96' => array('showitem' => 'type,role,role_freetext,publication,publication_symmetric,date_range,freetext'),
-    ),
-    'palettes' => array(
-        '1' => array('showitem' => ''),
-    ),
-    'columns' => array(
+        '90' => ['showitem' => 'type,role,role_freetext,person,publication,date_range,freetext'],
+        '91' => ['showitem' => 'type,role,role_freetext,project,publication,date_range,freetext'],
+        '92' => ['showitem' => 'type,role,role_freetext,unit,publication,date_range,freetext'],
+        '93' => ['showitem' => 'type,role,role_freetext,medium,publication,date_range,freetext'],
+        '94' => ['showitem' => 'type,role,role_freetext,news,publication,date_range,freetext'],
+        '95' => ['showitem' => 'type,role,role_freetext,event,publication,date_range,freetext'],
+        '96' => ['showitem' => 'type,role,role_freetext,publication,publication_symmetric,date_range,freetext'],
+    ],
+    'palettes' => [
+        '1' => ['showitem' => ''],
+    ],
+    'columns' => [
         'sys_language_uid' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
@@ -164,141 +165,141 @@ return array(
                 'default' => 0,
             ],
         ],
-        'l10n_diffsource' => array(
-            'config' => array(
+        'l10n_diffsource' => [
+            'config' => [
                 'type' => 'passthrough',
-            ),
-        ),
-        't3ver_label' => array(
+            ],
+        ],
+        't3ver_label' => [
             'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.versionLabel',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '30',
                 'max' => '255',
-            )
-        ),
-        'hidden' => array(
+            ]
+        ],
+        'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
-            'config' => array(
+            'config' => [
                 'type' => 'check',
-            ),
-        ),
-        'starttime' => array(
+            ],
+        ],
+        'starttime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.starttime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '10',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-            ),
-        ),
-        'endtime' => array(
+            ],
+        ],
+        'endtime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.endtime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '8',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-                'range' => array(
+                'range' => [
                     'upper' => mktime(0, 0, 0, 12, 31, date('Y') + 10),
                     'lower' => mktime(0, 0, 0, date('m') - 1, date('d'), date('Y'))
-                ),
-            ),
-        ),
-        'persistent_identifier' => array(
-            'config' => array(
+                ],
+            ],
+        ],
+        'persistent_identifier' => [
+            'config' => [
                 'type' => 'passthrough',
-            ),
-        ),
-        'sorting' => array(
-            'config' => array(
+            ],
+        ],
+        'sorting' => [
+            'config' => [
                 'type' => 'passthrough',
-            ),
-        ),
-        'sorting_symmetric' => array(
-            'config' => array(
+            ],
+        ],
+        'sorting_symmetric' => [
+            'config' => [
                 'type' => 'passthrough',
-            ),
-        ),
-        'type' => array(
+            ],
+        ],
+        'type' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_relations.type',
             'l10n_mode' => 'exclude',
             'l10n_display' => 'defaultAsReadonly',
-            'config' => array(
+            'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'size' => 1,
                 'minitems' => 1,
                 'maxitems' => 1,
                 'eval' => 'required',
-            ),
-        ),
-        'role' => array(
+            ],
+        ],
+        'role' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_relations.role',
             'l10n_mode' => 'exclude',
             'l10n_display' => 'defaultAsReadonly',
-            'config' => array(
+            'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'foreign_table' => 'tx_academy_domain_model_roles',
                 'foreign_table_where' => 'AND tx_academy_domain_model_roles.sys_language_uid IN (-1,###REC_FIELD_sys_language_uid###) ORDER BY tx_academy_domain_model_roles.title',
-                'items' => array(
-                    array('', 0),
-                ),
+                'items' => [
+                    ['', 0],
+                ],
                 'minitems' => 0,
                 'maxitems' => 1,
-            ),
-        ),
-        'role_freetext' => array(
+            ],
+        ],
+        'role_freetext' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_relations.role_freetext',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 20,
                 'eval' => 'trim'
-            ),
-        ),
-        'date_range' => array(
+            ],
+        ],
+        'date_range' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xlf:tx_academy_domain_model_relations.date_range',
             'l10n_mode' => 'exclude',
             'l10n_display' => 'defaultAsReadonly',
-            'config' => array(
+            'config' => [
                 'type' => 'inline',
                 'foreign_table' => 'tx_chftime_domain_model_dateranges',
                 'foreign_field' => 'parent',
                 'foreign_table_field' => 'tablename',
                 'minitems' => 0,
                 'maxitems' => 1,
-                'behaviour' => array(
+                'behaviour' => [
                     'disableMovingChildrenWithParent' => 1,
-                ),
-                'appearance' => array(
+                ],
+                'appearance' => [
                     'collapseAll' => 1,
                     'expandSingle' => 1,
                     'newRecordLinkAddTitle' => 1,
                     'newRecordLinkPosition' => 'bottom',
                     'levelLinksPosition' => 'bottom',
-                ),
-            ),
-        ),
-        'project' => array(
+                ],
+            ],
+        ],
+        'project' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_relations.project',
 //            'l10n_mode' => 'exclude',
 //            'l10n_display' => 'defaultAsReadonly',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'tx_academy_domain_model_projects',
@@ -308,14 +309,14 @@ return array(
                 'behaviour' => [
                     'allowLanguageSynchronization' => true,
                 ],
-            ),
-        ),
-        'project_symmetric' => array(
+            ],
+        ],
+        'project_symmetric' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_relations.project',
 //            'l10n_mode' => 'exclude',
 //            'l10n_display' => 'defaultAsReadonly',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'tx_academy_domain_model_projects',
@@ -325,14 +326,14 @@ return array(
                 'behaviour' => [
                     'allowLanguageSynchronization' => true,
                 ],
-            ),
-        ),
-        'event' => array(
+            ],
+        ],
+        'event' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_relations.event',
 //            'l10n_mode' => 'exclude',
 //            'l10n_display' => 'defaultAsReadonly',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'tx_news_domain_model_news',
@@ -342,14 +343,14 @@ return array(
                 'behaviour' => [
                     'allowLanguageSynchronization' => true,
                 ],
-            ),
-        ),
-        'event_symmetric' => array(
+            ],
+        ],
+        'event_symmetric' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_relations.event',
 //            'l10n_mode' => 'exclude',
 //            'l10n_display' => 'defaultAsReadonly',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'tx_news_domain_model_news',
@@ -359,14 +360,14 @@ return array(
                 'behaviour' => [
                     'allowLanguageSynchronization' => true,
                 ],
-            ),
-        ),
-        'person' => array(
+            ],
+        ],
+        'person' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_relations.person',
 //            'l10n_mode' => 'exclude',
 //            'l10n_display' => 'defaultAsReadonly',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'tx_academy_domain_model_persons',
@@ -376,14 +377,14 @@ return array(
                 'behaviour' => [
                     'allowLanguageSynchronization' => true,
                 ],
-            ),
-        ),
-        'person_symmetric' => array(
+            ],
+        ],
+        'person_symmetric' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_relations.person',
 //            'l10n_mode' => 'exclude',
 //            'l10n_display' => 'defaultAsReadonly',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'tx_academy_domain_model_persons',
@@ -393,14 +394,14 @@ return array(
                 'behaviour' => [
                     'allowLanguageSynchronization' => true,
                 ],
-            ),
-        ),
-        'medium' => array(
+            ],
+        ],
+        'medium' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_relations.medium',
 //            'l10n_mode' => 'exclude',
 //            'l10n_display' => 'defaultAsReadonly',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'tx_academy_domain_model_media',
@@ -410,14 +411,14 @@ return array(
                 'behaviour' => [
                     'allowLanguageSynchronization' => true,
                 ],
-            ),
-        ),
-        'medium_symmetric' => array(
+            ],
+        ],
+        'medium_symmetric' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_relations.medium',
 //            'l10n_mode' => 'exclude',
 //            'l10n_display' => 'defaultAsReadonly',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'tx_academy_domain_model_media',
@@ -427,14 +428,14 @@ return array(
                 'behaviour' => [
                     'allowLanguageSynchronization' => true,
                 ],
-            ),
-        ),
-        'news' => array(
+            ],
+        ],
+        'news' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_relations.news',
 //            'l10n_mode' => 'exclude',
 //            'l10n_display' => 'defaultAsReadonly',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'tx_news_domain_model_news',
@@ -444,14 +445,14 @@ return array(
                 'behaviour' => [
                     'allowLanguageSynchronization' => true,
                 ],
-            ),
-        ),
-        'news_symmetric' => array(
+            ],
+        ],
+        'news_symmetric' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_relations.news',
 //            'l10n_mode' => 'exclude',
 //            'l10n_display' => 'defaultAsReadonly',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'tx_news_domain_model_news',
@@ -461,14 +462,14 @@ return array(
                 'behaviour' => [
                     'allowLanguageSynchronization' => true,
                 ],
-            ),
-        ),
-        'unit' => array(
+            ],
+        ],
+        'unit' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_relations.unit',
 //            'l10n_mode' => 'exclude',
 //            'l10n_display' => 'defaultAsReadonly',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'tx_academy_domain_model_units',
@@ -478,14 +479,14 @@ return array(
                 'behaviour' => [
                     'allowLanguageSynchronization' => true,
                 ],
-            ),
-        ),
-        'unit_symmetric' => array(
+            ],
+        ],
+        'unit_symmetric' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_relations.unit',
 //            'l10n_mode' => 'exclude',
 //            'l10n_display' => 'defaultAsReadonly',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'tx_academy_domain_model_units',
@@ -495,14 +496,14 @@ return array(
                 'behaviour' => [
                     'allowLanguageSynchronization' => true,
                 ],
-            ),
-        ),
-        'product' => array(
+            ],
+        ],
+        'product' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_relations.product',
 //            'l10n_mode' => 'exclude',
 //            'l10n_display' => 'defaultAsReadonly',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'tx_academy_domain_model_products',
@@ -512,14 +513,14 @@ return array(
                 'behaviour' => [
                     'allowLanguageSynchronization' => true,
                 ],
-            ),
-        ),
-        'product_symmetric' => array(
+            ],
+        ],
+        'product_symmetric' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_relations.product_symmetric',
 //            'l10n_mode' => 'exclude',
 //            'l10n_display' => 'defaultAsReadonly',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'tx_academy_domain_model_products',
@@ -529,14 +530,14 @@ return array(
                 'behaviour' => [
                     'allowLanguageSynchronization' => true,
                 ],
-            ),
-        ),
-        'service' => array(
+            ],
+        ],
+        'service' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_relations.service',
 //            'l10n_mode' => 'exclude',
 //            'l10n_display' => 'defaultAsReadonly',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'tx_academy_domain_model_services',
@@ -546,14 +547,14 @@ return array(
                 'behaviour' => [
                     'allowLanguageSynchronization' => true,
                 ],
-            ),
-        ),
-        'service_symmetric' => array(
+            ],
+        ],
+        'service_symmetric' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_relations.service_symmetric',
 //            'l10n_mode' => 'exclude',
 //            'l10n_display' => 'defaultAsReadonly',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'tx_academy_domain_model_services',
@@ -563,14 +564,14 @@ return array(
                 'behaviour' => [
                     'allowLanguageSynchronization' => true,
                 ],
-            ),
-        ),
-        'publication' => array(
+            ],
+        ],
+        'publication' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_relations.publication',
 //            'l10n_mode' => 'exclude',
 //            'l10n_display' => 'defaultAsReadonly',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'tx_academy_domain_model_publications',
@@ -580,14 +581,14 @@ return array(
                 'behaviour' => [
                     'allowLanguageSynchronization' => true,
                 ],
-            ),
-        ),
-        'publication_symmetric' => array(
+            ],
+        ],
+        'publication_symmetric' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_relations.publication_symmetric',
 //            'l10n_mode' => 'exclude',
 //            'l10n_display' => 'defaultAsReadonly',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'tx_academy_domain_model_publications',
@@ -597,14 +598,14 @@ return array(
                 'behaviour' => [
                     'allowLanguageSynchronization' => true,
                 ],
-            ),
-        ),
-        'hcard' => array(
+            ],
+        ],
+        'hcard' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_relations.hcard',
 //            'l10n_mode' => 'exclude',
 //            'l10n_display' => 'defaultAsReadonly',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'tx_academy_domain_model_hcards',
@@ -614,18 +615,18 @@ return array(
                 'behaviour' => [
                     'allowLanguageSynchronization' => true,
                 ],
-            ),
-        ),
-        'freetext' => array(
+            ],
+        ],
+        'freetext' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_relations.freetext',
-            'config' => array(
+            'config' => [
                 'type' => 'text',
                 'cols' => 40,
                 'rows' => 10,
                 'eval' => 'trim',
                 'default' => '',
-            ),
-        ),
-    ),
-);
+            ],
+        ],
+    ],
+];

--- a/Configuration/TCA/tx_academy_domain_model_roles.php
+++ b/Configuration/TCA/tx_academy_domain_model_roles.php
@@ -1,10 +1,11 @@
 <?php
-if (!defined('TYPO3_MODE')) {
-    die ('Access denied.');
-}
 
-return array(
-    'ctrl' => array(
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+defined('TYPO3') or die();
+
+return [
+    'ctrl' => [
         'title' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_roles',
         'label' => 'title',
         'default_sortby' => 'ORDER BY title ASC',
@@ -17,15 +18,15 @@ return array(
         'transOrigPointerField' => 'l10n_parent',
         'transOrigDiffSourceField' => 'l10n_diffsource',
         'delete' => 'deleted',
-        'enablecolumns' => array(
+        'enablecolumns' => [
             'disabled' => 'hidden',
             'starttime' => 'starttime',
             'endtime' => 'endtime',
-        ),
+        ],
         'searchFields' => 'title',
-        'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_roles.svg'
-    ),
-    'interface' => array(
+        'iconfile' => ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_roles.svg'
+    ],
+    'interface' => [
         'showRecordFieldList' => '
             sys_language_uid, 
             l10n_parent, 
@@ -34,9 +35,9 @@ return array(
             persistent_identifier,
             title
         ',
-    ),
-    'types' => array(
-        '1' => array(
+    ],
+    'types' => [
+        '1' => [
             'showitem' => '
             --div--;LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_roles.div1,
                 hidden,
@@ -47,12 +48,12 @@ return array(
                 l10n_parent,
                 l10n_diffsource
         '
-        ),
-    ),
-    'palettes' => array(
-        '1' => array('showitem' => ''),
-    ),
-    'columns' => array(
+        ],
+    ],
+    'palettes' => [
+        '1' => ['showitem' => ''],
+    ],
+    'columns' => [
         'sys_language_uid' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
@@ -70,87 +71,87 @@ return array(
                 'default' => 0,
             ]
         ],
-        'l10n_parent' => array(
+        'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
             'exclude' => 1,
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.l18n_parent',
-            'config' => array(
+            'config' => [
                 'type' => 'select',
-                'items' => array(
-                    array('', 0),
-                ),
+                'items' => [
+                    ['', 0],
+                ],
                 'foreign_table' => 'tx_academy_domain_model_roles',
                 'foreign_table_where' => 'AND tx_academy_domain_model_roles.pid=###CURRENT_PID### AND tx_academy_domain_model_roles.sys_language_uid IN (-1,0)',
-            ),
-        ),
-        'l10n_diffsource' => array(
-            'config' => array(
+            ],
+        ],
+        'l10n_diffsource' => [
+            'config' => [
                 'type' => 'passthrough',
-            ),
-        ),
-        't3ver_label' => array(
+            ],
+        ],
+        't3ver_label' => [
             'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.versionLabel',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '30',
                 'max' => '255',
-            )
-        ),
-        'hidden' => array(
+            ]
+        ],
+        'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
-            'config' => array(
+            'config' => [
                 'type' => 'check',
-            ),
-        ),
-        'starttime' => array(
+            ],
+        ],
+        'starttime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.starttime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '10',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-            ),
-        ),
-        'endtime' => array(
+            ],
+        ],
+        'endtime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.endtime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '8',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-                'range' => array(
+                'range' => [
                     'upper' => mktime(0, 0, 0, 12, 31, date('Y') + 10),
                     'lower' => mktime(0, 0, 0, date('m') - 1, date('d'), date('Y'))
-                ),
-            ),
-        ),
-        'persistent_identifier' => array(
+                ],
+            ],
+        ],
+        'persistent_identifier' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xlf:tx_academy_domain_model_roles.persistent_identifier',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim',
                 'readOnly' => 1
-            ),
-        ),
-        'title' => array(
+            ],
+        ],
+        'title' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_roles.title',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim,required'
-            ),
-        )
-    ),
-);
+            ],
+        ]
+    ],
+];

--- a/Configuration/TCA/tx_academy_domain_model_services.php
+++ b/Configuration/TCA/tx_academy_domain_model_services.php
@@ -1,10 +1,8 @@
 <?php
-if (!defined('TYPO3_MODE')) {
-    die ('Access denied.');
-}
+defined('TYPO3') or die();
 
-return array(
-    'ctrl' => array(
+return [
+    'ctrl' => [
         'title' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_services',
         'label' => 'title',
         'default_sortby' => 'ORDER BY title ASC',
@@ -17,15 +15,15 @@ return array(
         'transOrigPointerField' => 'l10n_parent',
         'transOrigDiffSourceField' => 'l10n_diffsource',
         'delete' => 'deleted',
-        'enablecolumns' => array(
+        'enablecolumns' => [
             'disabled' => 'hidden',
             'starttime' => 'starttime',
             'endtime' => 'endtime',
-        ),
+        ],
         'searchFields' => 'persistent_identifier,identifier,title,acronym,description',
         'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_services.svg'
-    ),
-    'interface' => array(
+    ],
+    'interface' => [
         'showRecordFieldList' => '
             sys_language_uid, 
             l10n_parent, 
@@ -38,12 +36,13 @@ return array(
             sorting, 
             page, 
             image,
-            description, 
+            description,
+            content_elements, 
             relations
         ',
-    ),
-    'types' => array(
-        '1' => array(
+    ],
+    'types' => [
+        '1' => [
             'showitem' => '
             --div--;LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_services.div1,
                 hidden,
@@ -58,6 +57,7 @@ return array(
             --div--;LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_services.div2,
                 image,
                 description,
+                content_elements,
             --div--;LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_services.div3,
                 relations,
             --div--;LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_services.div5,
@@ -67,12 +67,12 @@ return array(
                 l10n_parent,
                 l10n_diffsource,
         '
-        ),
-    ),
-    'palettes' => array(
-        '1' => array('showitem' => ''),
-    ),
-    'columns' => array(
+        ],
+    ],
+    'palettes' => [
+        '1' => ['showitem' => ''],
+    ],
+    'columns' => [
         'sys_language_uid' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
@@ -90,106 +90,106 @@ return array(
                 'default' => 0,
             ]
         ],
-        'l10n_parent' => array(
+        'l10n_parent' => [
             'displayCond' => 'FIELD:sys_language_uid:>:0',
             'exclude' => 1,
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.l18n_parent',
-            'config' => array(
+            'config' => [
                 'type' => 'select',
-                'items' => array(
-                    array('', 0),
-                ),
+                'items' => [
+                    ['', 0],
+                ],
                 'foreign_table' => 'tx_academy_domain_model_services',
                 'foreign_table_where' => 'AND tx_academy_domain_model_services.pid=###CURRENT_PID### AND tx_academy_domain_model_services.sys_language_uid IN (-1,0)',
-            ),
-        ),
-        'l10n_diffsource' => array(
-            'config' => array(
+            ],
+        ],
+        'l10n_diffsource' => [
+            'config' => [
                 'type' => 'passthrough',
-            ),
-        ),
-        't3ver_label' => array(
+            ],
+        ],
+        't3ver_label' => [
             'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.versionLabel',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '30',
                 'max' => '255',
-            )
-        ),
-        'hidden' => array(
+            ]
+        ],
+        'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
-            'config' => array(
+            'config' => [
                 'type' => 'check',
-            ),
-        ),
-        'starttime' => array(
+            ],
+        ],
+        'starttime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.starttime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '10',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-            ),
-        ),
-        'endtime' => array(
+            ],
+        ],
+        'endtime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.endtime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '8',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-                'range' => array(
+                'range' => [
                     'upper' => mktime(0, 0, 0, 12, 31, date('Y') + 10),
                     'lower' => mktime(0, 0, 0, date('m') - 1, date('d'), date('Y'))
-                ),
-            ),
-        ),
-        'persistent_identifier' => array(
+                ],
+            ],
+        ],
+        'persistent_identifier' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xlf:tx_academy_domain_model_services.persistent_identifier',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim',
                 'readOnly' => 1
-            ),
-        ),
-        'identifier' => array(
+            ],
+        ],
+        'identifier' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_services.identifier',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
-        'title' => array(
+            ],
+        ],
+        'title' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_services.title',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim,required'
-            ),
-        ),
-        'acronym' => array(
+            ],
+        ],
+        'acronym' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_services.acronym',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
+            ],
+        ],
         'slug' => [
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_services.slug',
             'exclude' => 1,
@@ -207,29 +207,29 @@ return array(
                 'default' => ''
             ],
         ],
-        'sorting' => array(
+        'sorting' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_services.sorting',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
-        'date_range' => array(
+            ],
+        ],
+        'date_range' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xlf:tx_academy_domain_model_services.date_range',
-            'config' => array(
+            'config' => [
                 'type' => 'inline',
                 'foreign_table' => 'tx_chftime_domain_model_dateranges',
                 'foreign_field' => 'parent',
                 'foreign_table_field' => 'tablename',
                 'minitems' => 0,
                 'maxitems' => 1,
-                'behaviour' => array(
+                'behaviour' => [
                     'disableMovingChildrenWithParent' => 1,
-                ),
-                'appearance' => array(
+                ],
+                'appearance' => [
                     'collapseAll' => 1,
                     'expandSingle' => 1,
                     'newRecordLinkAddTitle' => 1,
@@ -238,13 +238,13 @@ return array(
                     'showSynchronizationLink' => 1,
                     'showPossibleLocalizationRecords' => 1,
                     'showAllLocalizationLink' => 1
-                ),
-            ),
-        ),
-        'page' => array(
+                ],
+            ],
+        ],
+        'page' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_services.page',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'pages',
@@ -254,55 +254,81 @@ return array(
                 'show_thumbs' => '1',
                 'eval' => 'int',
                 'default' => 0,
-                'wizards' => array(
-                    'suggest' => array(
+                'wizards' => [
+                    'suggest' => [
                         'type' => 'suggest',
-                    ),
-                ),
-            ),
-        ),
-        'image' => array(
+                    ],
+                ],
+            ],
+        ],
+        'image' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_services.image',
-            'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig('image', array(
-                'appearance' => array(
+            'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig('image', [
+                'appearance' => [
                     'createNewRelationLinkTitle' => 'LLL:EXT:cms/locallang_ttc.xlf:images.addFileReference'
-                ),
+                ],
                 'minitems' => 0,
                 'maxitems' => 1,
-                'foreign_types' => array(
-                    '0' => array(
+                'foreign_types' => [
+                    '0' => [
                         'showitem' => '
                             --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
                             --palette--;;filePalette'
-                    ),
-                    \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => array(
+                    ],
+                    \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => [
                         'showitem' => '
                             --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
                             --palette--;;filePalette'
-                    ),
-                )
-            ),
+                    ],
+                ]
+            ],
             $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']),
-        ),
-        'description' => array(
+        ],
+        'description' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_services.description',
-            'config' => array(
+            'config' => [
                 'type' => 'text',
                 'cols' => 40,
                 'rows' => 15,
                 'eval' => 'trim',
                 'softref' => 'rtehtmlarea_images,typolink_tag,images,email[subst],url',
                 'enableRichtext' => true,
-            ),
-        ),
-        'relations' => array(
+            ],
+        ],
+        'content_elements' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xlf:tx_academy_domain_model_services.content_elements',
+            'config' => [
+                'type' => 'inline',
+                'allowed' => 'tt_content',
+                'foreign_table' => 'tt_content',
+                'foreign_sortby' => 'sorting',
+                'foreign_field' => 'tx_academy_parent',
+                'foreign_table_field' => 'tx_academy_tablename',
+                'minitems' => 0,
+                'maxitems' => 99,
+                'appearance' => [
+                    'collapseAll' => true,
+                    'expandSingle' => true,
+                    'levelLinksPosition' => 'bottom',
+                    'useSortable' => true,
+                    'enabledControls' => [
+                        'info' => false,
+                    ]
+                ],
+                'behaviour' => [
+                    'allowLanguageSynchronization' => true,
+                ],
+            ]
+        ],
+        'relations' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_services.relations',
             'l10n_display' => 'defaultAsReadonly',
             'l10n_mode' => 'exclude',
-            'config' => array(
+            'config' => [
                 'type' => 'inline',
                 'foreign_table' => 'tx_academy_domain_model_relations',
                 'foreign_field' => 'service',
@@ -310,16 +336,16 @@ return array(
                 'symmetric_field' => 'service_symmetric',
                 'symmetric_sortby' => 'sorting_symmetric',
                 'maxitems' => 9999,
-                'behaviour' => array(
+                'behaviour' => [
                     'disableMovingChildrenWithParent' => 1,
 //                    'allowLanguageSynchronization' => true,
-                ),
-                'appearance' => array(
+                ],
+                'appearance' => [
                     'collapseAll' => 1,
                     'expandSingle' => 1,
                     'useSortable' => true,
                     'levelLinksPosition' => 'bottom',
-                ),
+                ],
                 'overrideChildTca' => [
                     'columns' => [
                         'type' => [
@@ -366,7 +392,7 @@ return array(
                         ]
                     ],
                 ],
-            ),
-        ),
-    ),
-);
+            ],
+        ],
+    ],
+];

--- a/Configuration/TCA/tx_academy_domain_model_units.php
+++ b/Configuration/TCA/tx_academy_domain_model_units.php
@@ -1,10 +1,12 @@
 <?php
-if (!defined('TYPO3_MODE')) {
-    die ('Access denied.');
-}
 
-return array(
-    'ctrl' => array(
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+defined('TYPO3') or die();
+
+return [
+    'ctrl' => [
         'title' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_units',
         'label' => 'title',
         'default_sortby' => 'ORDER BY title ASC',
@@ -17,15 +19,15 @@ return array(
         'transOrigPointerField' => 'l10n_parent',
         'transOrigDiffSourceField' => 'l10n_diffsource',
         'delete' => 'deleted',
-        'enablecolumns' => array(
+        'enablecolumns' => [
             'disabled' => 'hidden',
             'starttime' => 'starttime',
             'endtime' => 'endtime',
-        ),
+        ],
         'searchFields' => 'persistent_identifier,title,acronym,description',
-        'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_units.svg'
-    ),
-    'interface' => array(
+        'iconfile' => ExtensionManagementUtility::extPath('academy') . 'Resources/Public/Icons/tx_academy_domain_model_units.svg'
+    ],
+    'interface' => [
         'showRecordFieldList' => '
             sys_language_uid, 
             l10n_parent, 
@@ -37,12 +39,13 @@ return array(
             sorting,
             page, 
             image,
-            description, 
+            description,
+            content_elements, 
             relations
         ',
-    ),
-    'types' => array(
-        '1' => array(
+    ],
+    'types' => [
+        '1' => [
             'showitem' => '
             --div--;LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_units.div1,
                 hidden,
@@ -57,6 +60,7 @@ return array(
             --div--;LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_units.div2,
                 image,
                 description;;;richtext[cut|copy|paste|formatblock|textcolor|bold|italic|underline|left|center|right|orderedlist|unorderedlist|outdent|indent|link|table|image|line|chMode]:rte_transform[mode=ts_css|imgpath=uploads/tx_academy/],
+                content_elements,
             --div--;LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_units.div3,
                 relations,
             --div--;LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_units.div5,
@@ -66,12 +70,12 @@ return array(
                 l10n_parent,
                 l10n_diffsource
         '
-        ),
-    ),
-    'palettes' => array(
-        '1' => array('showitem' => ''),
-    ),
-    'columns' => array(
+        ],
+    ],
+    'palettes' => [
+        '1' => ['showitem' => ''],
+    ],
+    'columns' => [
         'sys_language_uid' => [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
@@ -102,84 +106,84 @@ return array(
                 'default' => 0,
             ],
         ],
-        'l10n_diffsource' => array(
-            'config' => array(
+        'l10n_diffsource' => [
+            'config' => [
                 'type' => 'passthrough',
-            ),
-        ),
-        't3ver_label' => array(
+            ],
+        ],
+        't3ver_label' => [
             'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.versionLabel',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '30',
                 'max' => '255',
-            )
-        ),
-        'hidden' => array(
+            ]
+        ],
+        'hidden' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
-            'config' => array(
+            'config' => [
                 'type' => 'check',
-            ),
-        ),
-        'starttime' => array(
+            ],
+        ],
+        'starttime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.starttime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '10',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-            ),
-        ),
-        'endtime' => array(
+            ],
+        ],
+        'endtime' => [
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.php:LGL.endtime',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => '8',
                 'max' => '20',
                 'eval' => 'datetime',
                 'checkbox' => '0',
                 'default' => '0',
-                'range' => array(
+                'range' => [
                     'upper' => mktime(0, 0, 0, 12, 31, date('Y') + 10),
                     'lower' => mktime(0, 0, 0, date('m') - 1, date('d'), date('Y'))
-                ),
-            ),
-        ),
-        'persistent_identifier' => array(
+                ],
+            ],
+        ],
+        'persistent_identifier' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xlf:tx_academy_domain_model_units.persistent_identifier',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim',
                 'readOnly' => 1
-            ),
-        ),
-        'title' => array(
+            ],
+        ],
+        'title' => [
             'exclude' => 0,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_units.title',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 80,
                 'eval' => 'trim,required'
-            ),
-        ),
-        'acronym' => array(
+            ],
+        ],
+        'acronym' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_units.acronym',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
+            ],
+        ],
         'slug' => [
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_units.slug',
             'exclude' => 1,
@@ -197,29 +201,29 @@ return array(
                 'default' => ''
             ],
         ],
-        'sorting' => array(
+        'sorting' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_units.sorting',
-            'config' => array(
+            'config' => [
                 'type' => 'input',
                 'size' => 30,
                 'eval' => 'trim'
-            ),
-        ),
-        'date_range' => array(
+            ],
+        ],
+        'date_range' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xlf:tx_academy_domain_model_products.date_range',
-            'config' => array(
+            'config' => [
                 'type' => 'inline',
                 'foreign_table' => 'tx_chftime_domain_model_dateranges',
                 'foreign_field' => 'parent',
                 'foreign_table_field' => 'tablename',
                 'minitems' => 0,
                 'maxitems' => 1,
-                'behaviour' => array(
+                'behaviour' => [
                     'disableMovingChildrenWithParent' => 1,
-                ),
-                'appearance' => array(
+                ],
+                'appearance' => [
                     'collapseAll' => 1,
                     'expandSingle' => 1,
                     'newRecordLinkAddTitle' => 1,
@@ -228,13 +232,13 @@ return array(
                     'showSynchronizationLink' => 1,
                     'showPossibleLocalizationRecords' => 1,
                     'showAllLocalizationLink' => 1
-                ),
-            ),
-        ),
-        'page' => array(
+                ],
+            ],
+        ],
+        'page' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_units.page',
-            'config' => array(
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'pages',
@@ -244,55 +248,81 @@ return array(
                 'show_thumbs' => '1',
                 'eval' => 'int',
                 'default' => 0,
-                'wizards' => array(
-                    'suggest' => array(
+                'wizards' => [
+                    'suggest' => [
                         'type' => 'suggest',
-                    ),
-                ),
-            ),
-        ),
-        'image' => array(
+                    ],
+                ],
+            ],
+        ],
+        'image' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_units.image',
-            'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig('image', array(
-                'appearance' => array(
+            'config' => ExtensionManagementUtility::getFileFieldTCAConfig('image', [
+                'appearance' => [
                     'createNewRelationLinkTitle' => 'LLL:EXT:cms/locallang_ttc.xlf:images.addFileReference'
-                ),
+                ],
                 'minitems' => 0,
                 'maxitems' => 1,
-                'foreign_types' => array(
-                    '0' => array(
+                'foreign_types' => [
+                    '0' => [
                         'showitem' => '
                             --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
                             --palette--;;filePalette'
-                    ),
-                    \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => array(
+                    ],
+                    File::FILETYPE_IMAGE => [
                         'showitem' => '
                             --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
                             --palette--;;filePalette'
-                    ),
-                )
-            ),
+                    ],
+                ]
+            ],
             $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']),
-        ),
-        'description' => array(
+        ],
+        'description' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_units.description',
-            'config' => array(
+            'config' => [
                 'type' => 'text',
                 'cols' => 40,
                 'rows' => 15,
                 'eval' => 'trim',
                 'softref' => 'rtehtmlarea_images,typolink_tag,images,email[subst],url',
                 'enableRichtext' => true,
-            ),
-        ),
-        'relations' => array(
+            ],
+        ],
+        'content_elements' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xlf:tx_academy_domain_model_units.content_elements',
+            'config' => [
+                'type' => 'inline',
+                'allowed' => 'tt_content',
+                'foreign_table' => 'tt_content',
+                'foreign_sortby' => 'sorting',
+                'foreign_field' => 'tx_academy_parent',
+                'foreign_table_field' => 'tx_academy_tablename',
+                'minitems' => 0,
+                'maxitems' => 99,
+                'appearance' => [
+                    'collapseAll' => true,
+                    'expandSingle' => true,
+                    'levelLinksPosition' => 'bottom',
+                    'useSortable' => true,
+                    'enabledControls' => [
+                        'info' => false,
+                    ]
+                ],
+                'behaviour' => [
+                    'allowLanguageSynchronization' => true,
+                ],
+            ]
+        ],
+        'relations' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xml:tx_academy_domain_model_units.relations',
             'l10n_mode' => 'exclude',
             'l10n_display' => 'defaultAsReadonly',
-            'config' => array(
+            'config' => [
                 'type' => 'inline',
                 'foreign_table' => 'tx_academy_domain_model_relations',
                 'foreign_field' => 'unit',
@@ -300,16 +330,16 @@ return array(
                 'symmetric_field' => 'unit_symmetric',
                 'symmetric_sortby' => 'sorting_symmetric',
                 'maxitems' => 9999,
-                'behaviour' => array(
+                'behaviour' => [
                     'disableMovingChildrenWithParent' => 1,
 //                    'allowLanguageSynchronization' => true,
-                ),
-                'appearance' => array(
+                ],
+                'appearance' => [
                     'collapseAll' => 1,
                     'expandSingle' => 1,
                     'useSortable' => true,
                     'levelLinksPosition' => 'bottom',
-                ),
+                ],
                 'overrideChildTca' => [
                     'columns' => [
                         'type' => [
@@ -364,7 +394,7 @@ return array(
                         ],
                     ],
                 ],
-            ),
-        ),
-    ),
-);
+            ],
+        ],
+    ],
+];

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -343,6 +343,10 @@
 				<source>Description</source>
 				<target>Beschreibung</target>
 			</trans-unit>
+			<trans-unit id="tx_academy_domain_model_projects.content_elements" resname="tx_academy_domain_model_projects.content_elements"  approved="yes">
+				<source>Content Elements</source>
+				<target>Inhaltselemente</target>
+			</trans-unit>
 			<trans-unit id="tx_academy_domain_model_projects.relations" resname="tx_academy_domain_model_projects.relations"  approved="yes">
 				<source>Relations (project)</source>
 				<target>Verknüpfungen (Projekt)</target>
@@ -406,6 +410,10 @@
 			<trans-unit id="tx_academy_domain_model_persons.page" resname="tx_academy_domain_model_persons.page"  approved="yes">
 				<source>Page with person information</source>
 				<target>Seite mit Personeninformationen</target>
+			</trans-unit>
+			<trans-unit id="tx_academy_domain_model_persons.content_elements" resname="tx_academy_domain_model_persons.content_elements"  approved="yes">
+				<source>Content Elements</source>
+				<target>Inhaltselemente</target>
 			</trans-unit>
 			<trans-unit id="tx_academy_domain_model_persons.image" resname="tx_academy_domain_model_persons.image"  approved="yes">
 				<source>Images</source>
@@ -483,6 +491,10 @@
 				<source>Description</source>
 				<target>Beschreibung</target>
 			</trans-unit>
+			<trans-unit id="tx_academy_domain_model_products.content_elements" resname="tx_academy_domain_model_products.content_elements"  approved="yes">
+				<source>Content Elements</source>
+				<target>Inhaltselemente</target>
+			</trans-unit>
 			<trans-unit id="tx_academy_domain_model_products.relations" resname="tx_academy_domain_model_products.relations"  approved="yes">
 				<source>Relations (product)</source>
 				<target>Verknüpfungen (Produkt)</target>
@@ -554,6 +566,10 @@
 			<trans-unit id="tx_academy_domain_model_services.description" resname="tx_academy_domain_model_services.description"  approved="yes">
 				<source>Description</source>
 				<target>Beschreibung</target>
+			</trans-unit>
+			<trans-unit id="tx_academy_domain_model_services.content_elements" resname="tx_academy_domain_model_services.content_elements"  approved="yes">
+				<source>Content Elements</source>
+				<target>Inhaltselemente</target>
 			</trans-unit>
 			<trans-unit id="tx_academy_domain_model_services.relations" resname="tx_academy_domain_model_services.relations"  approved="yes">
 				<source>Relations (service)</source>
@@ -646,6 +662,10 @@
 			<trans-unit id="tx_academy_domain_model_publications.bibliographic_note" resname="tx_academy_domain_model_publications.bibliographic_note"  approved="yes">
 				<source>Bibliographic note</source>
 				<target>Bibliographische Angaben</target>
+			</trans-unit>
+			<trans-unit id="tx_academy_domain_model_publications.content_elements" resname="tx_academy_domain_model_publications.content_elements"  approved="yes">
+				<source>Content Elements</source>
+				<target>Inhaltselemente</target>
 			</trans-unit>
 			<trans-unit id="tx_academy_domain_model_publications.image" resname="tx_academy_domain_model_publications.image"  approved="yes">
 				<source>Images</source>
@@ -1274,6 +1294,10 @@
 			<trans-unit id="tx_academy_domain_model_units.description" resname="tx_academy_domain_model_units.description"  approved="yes">
 				<source>Description</source>
 				<target>Beschreibung</target>
+			</trans-unit>
+			<trans-unit id="tx_academy_domain_model_units.content_elements" resname="tx_academy_domain_model_units.content_elements"  approved="yes">
+				<source>Content Elements</source>
+				<target>Inhaltselemente</target>
 			</trans-unit>
 			<trans-unit id="tx_academy_domain_model_units.relations" resname="tx_academy_domain_model_units.relations"  approved="yes">
 				<source>Relations (unit)</source>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -258,6 +258,9 @@
 			<trans-unit id="tx_academy_domain_model_projects.description" resname="tx_academy_domain_model_projects.description" >
 				<source>Description</source>
 			</trans-unit>
+			<trans-unit id="tx_academy_domain_model_projects.content_elements" resname="tx_academy_domain_model_projects.content_elements" >
+				<source>Content Elements</source>
+			</trans-unit>
 			<trans-unit id="tx_academy_domain_model_projects.relations" resname="tx_academy_domain_model_projects.relations" >
 				<source>Relations (project)</source>
 			</trans-unit>
@@ -306,6 +309,9 @@
 			<trans-unit id="tx_academy_domain_model_persons.page" resname="tx_academy_domain_model_persons.page" >
 				<source>Page with person information</source>
 			</trans-unit>
+            <trans-unit id="tx_academy_domain_model_persons.content_elements" resname="tx_academy_domain_model_persons.content_elements" >
+                <source>Content Elements</source>
+            </trans-unit>
 			<trans-unit id="tx_academy_domain_model_persons.image" resname="tx_academy_domain_model_persons.image" >
 				<source>Images</source>
 			</trans-unit>
@@ -363,6 +369,9 @@
 			<trans-unit id="tx_academy_domain_model_products.description" resname="tx_academy_domain_model_products.description" >
 				<source>Description</source>
 			</trans-unit>
+			<trans-unit id="tx_academy_domain_model_products.content_elements" resname="tx_academy_domain_model_products.content_elements" >
+				<source>Content Elements</source>
+			</trans-unit>
 			<trans-unit id="tx_academy_domain_model_products.relations" resname="tx_academy_domain_model_products.relations" >
 				<source>Relations (product)</source>
 			</trans-unit>
@@ -416,6 +425,9 @@
 			</trans-unit>
 			<trans-unit id="tx_academy_domain_model_services.description" resname="tx_academy_domain_model_services.description" >
 				<source>Description</source>
+			</trans-unit>
+			<trans-unit id="tx_academy_domain_model_services.content_elements" resname="tx_academy_domain_model_services.content_elements" >
+				<source>Content Elements</source>
 			</trans-unit>
 			<trans-unit id="tx_academy_domain_model_services.relations" resname="tx_academy_domain_model_services.relations" >
 				<source>Relations (service)</source>
@@ -485,6 +497,9 @@
 			</trans-unit>
 			<trans-unit id="tx_academy_domain_model_publications.bibliographic_note" resname="tx_academy_domain_model_publications.bibliographic_note" >
 				<source>Bibliographic note</source>
+			</trans-unit>
+			<trans-unit id="tx_academy_domain_model_publications.content_elements" resname="tx_academy_domain_model_publications.content_elements" >
+				<source>Content Elements</source>
 			</trans-unit>
 			<trans-unit id="tx_academy_domain_model_publications.image" resname="tx_academy_domain_model_publications.image" >
 				<source>Images</source>
@@ -956,6 +971,9 @@
 			</trans-unit>
 			<trans-unit id="tx_academy_domain_model_units.description" resname="tx_academy_domain_model_units.description" >
 				<source>Description</source>
+			</trans-unit>
+			<trans-unit id="tx_academy_domain_model_units.content_elements" resname="tx_academy_domain_model_units.content_elements" >
+				<source>Content Elements</source>
 			</trans-unit>
 			<trans-unit id="tx_academy_domain_model_units.relations" resname="tx_academy_domain_model_units.relations" >
 				<source>Relations (unit)</source>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -9,6 +9,9 @@ CREATE TABLE tx_academy_domain_model_projects (
 	sorting varchar(255) DEFAULT '' NOT NULL,
 	description text NOT NULL,
 
+    # tt_content (1:n)
+    content_elements int(11) DEFAULT '0' NOT NULL,
+
     # slug
     slug varchar(2048) DEFAULT '' NOT NULL,
 
@@ -70,6 +73,9 @@ CREATE TABLE tx_academy_domain_model_units (
 	sorting varchar(255) DEFAULT '' NOT NULL,
 	description text NOT NULL,
 
+    # tt_content (1:n)
+    content_elements int(11) DEFAULT '0' NOT NULL,
+
     # slug
     slug varchar(2048) DEFAULT '' NOT NULL,
 
@@ -128,6 +134,9 @@ CREATE TABLE tx_academy_domain_model_persons (
 	honorific_prefix varchar(80) DEFAULT '' NOT NULL,
 	honorific_suffix varchar(80) DEFAULT '' NOT NULL,
 	sorting varchar(255) DEFAULT '' NOT NULL,
+
+    # tt_content (1:n)
+    content_elements int(11) DEFAULT '0' NOT NULL,
 
     # slug
     slug varchar(2048) DEFAULT '' NOT NULL,
@@ -257,6 +266,9 @@ CREATE TABLE tx_academy_domain_model_products (
 	# cfVersInfo
 	version varchar(40) DEFAULT '' NOT NULL,
 
+    # tt_content (1:n)
+    content_elements int(11) DEFAULT '0' NOT NULL,
+
 	# sys_file (1:n)
 	image int(11) DEFAULT '0' NOT NULL,
 
@@ -344,6 +356,9 @@ CREATE TABLE tx_academy_domain_model_publications (
 	# cfBiblNote
 	bibliographic_note varchar(255) DEFAULT '' NOT NULL,
 
+    # tt_content (1:n)
+    content_elements int(11) DEFAULT '0' NOT NULL,
+
 	# sys_file (1:n)
 	image int(11) DEFAULT '0' NOT NULL,
 
@@ -411,6 +426,9 @@ CREATE TABLE tx_academy_domain_model_services (
 	acronym varchar(40) DEFAULT '' NOT NULL,
 	# cfDescr
 	description text NOT NULL,
+
+    # tt_content (1:n)
+    content_elements int(11) DEFAULT '0' NOT NULL,
 
 	# sys_file (1:n)
 	image int(11) DEFAULT '0' NOT NULL,
@@ -894,4 +912,10 @@ CREATE TABLE sys_category (
 	persistent_identifier varchar(255) DEFAULT '' NOT NULL,
 
 	KEY persistent_identifier (persistent_identifier)
+);
+
+CREATE TABLE tt_content (
+    tx_academy_parent int(11) DEFAULT '0' NOT NULL,
+    tx_academy_tablename varchar(255) DEFAULT '' NOT NULL,
+    KEY tx_academy_parent (tx_academy_parent)
 );


### PR DESCRIPTION
Closes #18

Introduces the possibility to add content elements to projects, persons, products, publications, services, and units. Therefore, fields must be added to the relevant database tables after extension update.

Additonally switches to short syntax and replaces the TYPO3_MODE as security gate in TCA Overrides with `defined('TYPO3') or die();` cause TYPO3_MODE is deprecated since v11 , see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.0/Deprecation-92947-DeprecateTYPO3_MODEAndTYPO3_REQUESTTYPEConstants.html#deprecation-92947 .

Note: Implementation of content elements ObjectStorage is not lazy. It could be adapted in the future. 
