### PR TITLE
Solve some open points regarding persons and media in TYPO3 12.4 version of the academy extension

### DIFF
--- a/Classes/Domain/Model/Media.php
+++ b/Classes/Domain/Model/Media.php
@@ -29,6 +29,7 @@ namespace Digicademy\Academy\Domain\Model;
 use Digicademy\Academy\Domain\Model\Traits\{CategoriesTrait,
     DescriptionTrait,
     ImageTrait,
+    PageTrait,
     PersistentIdentifierTrait,
     RelationsTrait,
     SlugTrait,
@@ -53,6 +54,7 @@ class Media extends AbstractEntity
     use CategoriesTrait;
     use DescriptionTrait;
     use ImageTrait;
+    use PageTrait;
     use PersistentIdentifierTrait;
     use RelationsTrait;
     use TitleTrait;

--- a/Classes/Domain/Model/Persons.php
+++ b/Classes/Domain/Model/Persons.php
@@ -102,34 +102,6 @@ class Persons extends AbstractEntity
     protected $honorificSuffix;
 
     /**
-     * cv
-     *
-     * @var string $cv
-     */
-    protected $cv;
-
-    /**
-     * expertise
-     *
-     * @var string $expertise
-     */
-    protected $expertise;
-
-    /**
-     * awards
-     *
-     * @var string $awards
-     */
-    protected $awards;
-
-    /**
-     * publications
-     *
-     * @var string $publications
-     */
-    protected $publications;
-
-    /**
      * Returns the given name
      *
      * @return string $givenName
@@ -227,85 +199,5 @@ class Persons extends AbstractEntity
     public function setHonorificSuffix(string $honorificSuffix): void
     {
         $this->honorificSuffix = $honorificSuffix;
-    }
-
-    /**
-     * Returns the CV
-     *
-     * @return string $cv
-     */
-    public function getCv(): string
-    {
-        return $this->cv;
-    }
-
-    /**
-     * Sets the CV
-     *
-     * @param string $cv
-     */
-    public function setCv(string $cv): void
-    {
-        $this->cv = $cv;
-    }
-
-    /**
-     * Returns the expertise
-     *
-     * @return string $expertise
-     */
-    public function getExpertise(): string
-    {
-        return $this->expertise;
-    }
-
-    /**
-     * Sets the expertise
-     *
-     * @param string $expertise
-     */
-    public function setExpertise(string $expertise): void
-    {
-        $this->expertise = $expertise;
-    }
-
-    /**
-     * Returns the awards
-     *
-     * @return string $awards
-     */
-    public function getAwards(): string
-    {
-        return $this->awards;
-    }
-
-    /**
-     * Sets the awards
-     *
-     * @param string $awards
-     */
-    public function setAwards(string $awards): void
-    {
-        $this->awards = $awards;
-    }
-
-    /**
-     * Returns the publications
-     *
-     * @return string $publications
-     */
-    public function getPublications(): string
-    {
-        return $this->publications;
-    }
-
-    /**
-     * Sets the publications
-     *
-     * @param string $publications
-     */
-    public function setPublications(string $publications): void
-    {
-        $this->publications = $publications;
     }
 }

--- a/Configuration/TCA/tx_academy_domain_model_media.php
+++ b/Configuration/TCA/tx_academy_domain_model_media.php
@@ -43,6 +43,7 @@ return [
                 title,
                 description;;;richtext[cut|copy|paste|formatblock|textcolor|bold|italic|underline|left|center|right|orderedlist|unorderedlist|outdent|indent|link|table|image|line|chMode]:rte_transform[mode=ts_css|imgpath=uploads/tx_academy/],
                 date_range,
+                page,
                 slug,
                 sorting,
                 image,
@@ -233,6 +234,25 @@ return [
                     'showSynchronizationLink' => 1,
                     'showPossibleLocalizationRecords' => 1,
                     'showAllLocalizationLink' => 1
+                ],
+            ],
+        ],
+        'page' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:academy/Resources/Private/Language/locallang_db.xlf:tx_academy_domain_model_media.page',
+            'config' => [
+                'type' => 'group',
+                'allowed' => 'pages',
+                'size' => '1',
+                'maxitems' => '1',
+                'minitems' => '0',
+                'show_thumbs' => '1',
+                'eval' => 'int',
+                'default' => 0,
+                'wizards' => [
+                    'suggest' => [
+                        'type' => 'suggest',
+                    ],
                 ],
             ],
         ],

--- a/Resources/Private/HTML/Partials/Persons/MemberListItem.html
+++ b/Resources/Private/HTML/Partials/Persons/MemberListItem.html
@@ -20,7 +20,6 @@
 
 <f:section name="Item">
 	<f:render partial="Hcards/VcardPerson" arguments="{person : person, nameWrap : 'h2'}" />
-	<p><strong><f:translate key="persons.expertise" />:</strong> {person.expertise}</p>
 	<p>
 		<f:link.action class="box icon more" controller="Persons" action="show" pageUid="1827" arguments="{person : person.uid}">
 			<f:translate key="persons.profileLink" />

--- a/Resources/Private/HTML/Templates/Search/SearchSingle.html
+++ b/Resources/Private/HTML/Templates/Search/SearchSingle.html
@@ -53,12 +53,6 @@
 							</f:if>
 						</f:else>
 					</f:if>
-					<f:if condition="{match.attrs.expertise}">
-						<br/>
-						<span>
-							<f:translate key="persons.expertise" />: <f:format.crop maxCharacters="160">{match.attrs.expertise}</f:format.crop>
-						</span>
-					</f:if>
 				</li>
 			</f:for>
 		</ul>

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -1391,6 +1391,10 @@
 				<source>Date range</source>
 				<target>Zeitraum</target>
 			</trans-unit>
+			<trans-unit id="tx_academy_domain_model_media.page" resname="tx_academy_domain_model_media.page"  approved="yes">
+				<source>Page with information</source>
+				<target>Seite mit Informationen</target>
+			</trans-unit>
 			<trans-unit id="tx_academy_domain_model_media.slug" resname="tx_academy_domain_model_media.slug"  approved="yes">
 				<source>URL Path Segment</source>
 				<target>URL Pfadsegment</target>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -1103,6 +1103,9 @@
 			<trans-unit id="tx_academy_domain_model_media.date_range" resname="tx_academy_domain_model_media.date_range" >
 				<source>Date range</source>
 			</trans-unit>
+			<trans-unit id="tx_academy_domain_model_media.page" resname="tx_academy_domain_model_media.page" >
+				<source>Page with information</source>
+			</trans-unit>
 			<trans-unit id="tx_academy_domain_model_media.slug" resname="tx_academy_domain_model_media.slug" >
 				<source>URL Path Segment</source>
 			</trans-unit>

--- a/Resources/Private/VCF/Templates/Persons/Show.vcf
+++ b/Resources/Private/VCF/Templates/Persons/Show.vcf
@@ -2,9 +2,6 @@
 VERSION:3.0
 N;CHARSET=utf-8:{person.familyName};{person.givenName};{person.additionalNames};{person.honorificPrefix};{person.honorificSuffix}
 FN;CHARSET=utf-8:{person.honorificPrefix} {person.givenName} {person.additionalNames} {person.familyName} {person.honorificSuffix}
-<f:if condition="{person.expertise}">
-NOTE;CHARSET=utf-8:{person.expertise}
-</f:if>
 <f:for each="{person.relations}" as="relation">
 	<f:if condition="{relation.type} == 10">
 		<f:for each="{relation.hcard.adr}" as="adr">


### PR DESCRIPTION
Fix #38 

With this merge some corrections regarding persons and media in the TYPO3 12.4 version of the academy extension are made. 

With the upgrade, the attributes cv, expertise, awards and publications were removed from the academy extension in ext_tables.sql and TCA, as they should be managed in specific instances. The merge also removes them from the domain model of persons. 

In the case of media, the page attribute is added to domain model media. This was already introduced in ext_tables.sql and the TCA of media.