### PR TITLE
fix: rename method following core

### DIFF
--- a/Classes/Xclass/Core/DataHandling/AcademyDataHandler.php
+++ b/Classes/Xclass/Core/DataHandling/AcademyDataHandler.php
@@ -1,5 +1,4 @@
 <?php
-// @TODO: check with 12.4 core
 namespace Digicademy\Academy\Xclass\Core\DataHandling;
 
 use TYPO3\CMS\Backend\Utility\BackendUtility;
@@ -24,7 +23,7 @@ class AcademyDataHandler extends DataHandler
      * @param array $workspaceOptions
      * @return string
      */
-    protected function copyRecord_processInline(
+    protected function copyRecord_processRelation(
         $table,
         $uid,
         $field,


### PR DESCRIPTION
note: the method copyRecord_processInline was renamed to copyRecord_processRelation in typo3 12.4 in the core. therefore, the patch regarding IRRE relations was not working anymore. method is renamed with this commit.

fixes #42 