### PR TITLE
fix: localized relations in unlocalized news and events

### DIFF
--- a/Classes/Xclass/Backend/Form/FormDataProvider/AcademyTcaInline.php
+++ b/Classes/Xclass/Backend/Form/FormDataProvider/AcademyTcaInline.php
@@ -37,7 +37,7 @@ class AcademyTcaInline extends TcaInline
         // all existing IRRE children (also those from other languages) are shown in the entity that is
         // not yet localized; this is quite confusing behaviour - localized IRRE children should
         // always only be shown in the respective language of their respective parent record
-        if ($fieldName == 'relations') {
+        if ($fieldName == 'relations' || $fieldName == 'news_relations' || $fieldName == 'event_relations') {
             $languageAwareConnectedUids = [];
             foreach ($connectedUidsOfDefaultLanguageRecord as $uid) {
                 // fetch the relation to get its language id

--- a/Classes/Xclass/Backend/Form/FormDataProvider/AcademyTcaInline.php
+++ b/Classes/Xclass/Backend/Form/FormDataProvider/AcademyTcaInline.php
@@ -37,7 +37,9 @@ class AcademyTcaInline extends TcaInline
         // all existing IRRE children (also those from other languages) are shown in the entity that is
         // not yet localized; this is quite confusing behaviour - localized IRRE children should
         // always only be shown in the respective language of their respective parent record
-        if ($fieldName == 'relations' || $fieldName == 'news_relations' || $fieldName == 'event_relations') {
+        // we need to take into account that the field name is different for news and events than for other
+        // relations
+        if ($fieldName == 'relations' || $fieldName == 'news_relations' || $fieldName == 'event_relations') {            
             $languageAwareConnectedUids = [];
             foreach ($connectedUidsOfDefaultLanguageRecord as $uid) {
                 // fetch the relation to get its language id


### PR DESCRIPTION
With this merge, ‘news_relations’ and ‘event_relations’ are also checked as field names in the TCAInline patch to prevent localised relations from being loaded into records that have not yet been localised.